### PR TITLE
refactor: modernizar operaciones/commentCard

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -5,6 +5,24 @@ Este documento registra las convenciones establecidas en Fase 1 del refactor
 a código **nuevo o tocado** de aquí en adelante — no implican un retrofit
 automático del código existente.
 
+## Flujo Git por dominio
+
+Cada dominio o subproyecto del refactor se desarrolla en una rama propia,
+creada antes de empezar a registrar cambios. El nombre sigue el patrón
+`refactor/fase-<n>-<dominio>` (por ejemplo,
+`refactor/fase-2-operations-coment-card`).
+
+Los cambios se guardan en commits pequeños y coherentes por responsabilidad
+(implementación, pruebas/documentación y correcciones posteriores cuando
+aplique). Al terminar y verificar el dominio:
+
+1. Publicar la rama en `origin`.
+2. Abrir un pull request contra `trunk`.
+3. Incluir en el PR un resumen de cambios, bugs corregidos y verificaciones
+   ejecutadas.
+
+No mezclar archivos locales o cambios ajenos al dominio en sus commits.
+
 ## Manejo de errores y respuestas HTTP
 
 El estándar oficial usa `AppError` (`src/errors/AppError.js`) y el
@@ -67,6 +85,72 @@ La respuesta de error resultante tiene esta forma:
 El retrofit de los controllers existentes al patrón nuevo se hace dominio
 por dominio en Fase 2. Dominios ya retrofiteados: `auth`, `staff`, `users`,
 `yachts`, `company`, `departaments`, `documentation`, `positions`, `roles`.
+Dominios de operaciones ya retrofiteados: `comentCard`.
+
+## Validación de identificadores codificados
+
+Los parámetros de ruta que contienen IDs codificados con hashids se validan
+inmediatamente después de `Utils.decode`. `decode` puede devolver `undefined`
+o lanzar ante una entrada malformada; ambos casos son errores de entrada y
+deben producir un `AppError` con status 400, no llegar como `undefined` a
+Sequelize ni convertirse en un 500 accidental.
+
+```js
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
+```
+
+Mientras no exista un middleware compartido de parámetros, este helper puede
+vivir local al controller. No agregar validación HTTP a `Utils.js`: ese módulo
+se mantiene limitado a `encode`/`decode`.
+
+## Transacciones Sequelize
+
+Para código nuevo o tocado se prefieren las transacciones administradas:
+
+```js
+return db.transaction(async (transaction) => {
+    const parent = await Parent.create(data, { transaction });
+    await Child.bulkCreate(children, { transaction });
+    return parent;
+});
+```
+
+Sequelize hace `commit` cuando el callback termina y `rollback` cuando lanza.
+Esto evita duplicar `commit`/`rollback` y, especialmente, evita el antipatrón
+`throw new Error(error.message)`, que elimina el tipo, stack y metadata del
+error original. Para inserts homogéneos usar `bulkCreate` en vez de un
+`Promise.all(Model.create(...))`.
+
+## Atributos de modelo y nombres de columnas
+
+Cuando un modelo declara, por ejemplo, `options` con
+`field: 'opciones'`, los payloads de `create`/`update` deben usar el nombre del
+**atributo Sequelize** (`options`). El nombre físico (`opciones`) se reserva
+para SQL, asociaciones antiguas o selecciones que deliberadamente preservan
+un contrato de respuesta legado.
+
+Antes de cambiar un nombre usado en `attributes`, comprobar también la forma
+JSON pública: reemplazar `nombre_completo` por `fullName`, aunque ambos apunten
+a la misma columna, cambia el contrato exitoso del endpoint.
+
+## Validación de relaciones en payloads
+
+Una foreign key válida no demuestra que el recurso pertenezca al agregado que
+se está modificando. Al actualizar hijos o registrar respuestas, comprobar que
+sus IDs pertenezcan al padre indicado (por ejemplo, que una pregunta enviada
+pertenezca a la comment card del QR). La restricción FK solo garantiza que la
+pregunta existe; sin esta validación se pueden mezclar datos entre formularios.
 
 ## Sufijo de archivos de servicios
 

--- a/docs/superpowers/specs/2026-07-28-fase-2-operations-coment-card-design.md
+++ b/docs/superpowers/specs/2026-07-28-fase-2-operations-coment-card-design.md
@@ -1,0 +1,82 @@
+# Fase 2 — Operaciones: Comment Card — diseño
+
+**Fecha:** 2026-07-28  
+**Estado:** Implementado
+
+## Contexto y alcance
+
+Primer dominio de operaciones después de completar los catálogos. El alcance
+incluye los 12 endpoints montados en `/api/coment_cards`, su controller,
+servicio, rutas Swagger y pruebas de dominio. Se conservan los paths existentes
+y la forma de las respuestas exitosas.
+
+## Hallazgos y decisiones
+
+- Los 12 handlers atrapaban todo error y respondían 400 con un string. Ahora
+  delegan a `errorHandler` mediante `next(error)`.
+- Los IDs hashids malformados se clasifican como 400. Los recursos individuales
+  inexistentes (comment card, QR o link activo por fecha) responden 404.
+- Los payloads de creación, actualización y respuesta se validan antes de tocar
+  la base de datos.
+- Las preguntas usadas al actualizar o responder deben pertenecer a la comment
+  card correspondiente. Una FK por sí sola no evita mezclar preguntas de otro
+  formulario.
+- `updateComentCard` escribía `opciones`, pero el atributo Sequelize es
+  `options`; el update podía ignorar silenciosamente las opciones. Se corrigió
+  y se cubrió con una prueba de regresión.
+- Los campos `scaleMin` y `scaleMax` se preservan tanto al crear como al
+  actualizar preguntas.
+- `getComentCardByDates` recibía `:yacht_id`, pero lo comparaba directamente
+  contra `coment_card_yacht_id`. Funcionaba por accidente cuando ambos
+  autoincrementos coincidían. Ahora filtra `card_yacht.yachtId` mediante la
+  asociación y la prueba desincroniza expresamente ambos IDs.
+- Las transacciones manuales fueron reemplazadas por transacciones administradas
+  para garantizar rollback y conservar el error original.
+- Las respuestas se insertan con `bulkCreate`; las consultas simples ya no
+  contienen `try/catch` que solo vuelve a lanzar el mismo error.
+- Se eliminaron imports sin uso (`mathjs`, `xlsx`, `dayjs`, `dotenv`) y
+  mutaciones con `map` usado solo por efectos secundarios.
+- Se preservan nombres JSON legados como `access_link` y `nombre_completo`,
+  aunque el modelo exponga atributos camelCase, para no romper consumidores.
+- El reporte conserva la compatibilidad con `yacht_id=undefined`, pero ahora
+  exige que `startDate` y `endDate` se envíen juntos y sean fechas válidas.
+
+## Contrato de errores
+
+| Caso | Status |
+|---|---:|
+| Hashid, fecha o payload inválido | 400 |
+| Comment card/QR/link individual inexistente | 404 |
+| Token ausente o inválido en rutas administrativas | 403 |
+| Sequelize, DB o error inesperado | 500 |
+
+Todos los errores que llegan al handler global usan:
+
+```json
+{ "error": { "message": "mensaje", "code": "AppError|INTERNAL_ERROR" } }
+```
+
+## Seguridad preservada
+
+Se mantiene el comportamiento previo de rutas:
+
+- Con JWT: listado administrativo, get/create/update/delete y asignaciones a
+  yates.
+- Públicas: links, formulario por QR/fecha, envío de respuesta y reporting.
+
+La exposición actual de links y reporting no se amplía ni se corrige dentro de
+este refactor para evitar un cambio de autorización no solicitado. Debe
+reevaluarse expresamente en una fase de hardening.
+
+## Verificación
+
+Las pruebas de dominio cubren casos felices, 400, 404, propagación a 500,
+persistencia de opciones/escalas, relaciones y transacciones. Swagger documenta
+los 12 endpoints y distingue rutas públicas de rutas con bearer token.
+
+## Reglas reutilizables para siguientes fases
+
+Las decisiones generales derivadas de este dominio quedaron añadidas a
+`docs/CONVENTIONS.md`: validación de hashids, transacciones administradas,
+atributos Sequelize frente a columnas físicas y validación de pertenencia de
+relaciones.

--- a/src/controllers/operations/comentCard/comentCard.controller.js
+++ b/src/controllers/operations/comentCard/comentCard.controller.js
@@ -1,190 +1,287 @@
-const { re } = require('mathjs');
 const ComentCardService = require('../../../services/operations/comentCard/comentCard.services');
+const AppError = require('../../../errors/AppError');
 const Utils = require('../../../utils/Utils');
-const XLSX = require('xlsx');
-const dayjs = require('dayjs');
 
-const getAllComentCards = async (req, res) => {
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
+
+const decodeOptionalId = (value, fieldName) => {
+    if (!value || value === 'undefined' || value === 'null') {
+        return undefined;
+    }
+    return decodeId(value, fieldName);
+};
+
+const requireValidDate = (value, fieldName) => {
+    if (!value || Number.isNaN(new Date(value).getTime())) {
+        throw new AppError(`${fieldName} inválida`, 400);
+    }
+    return value;
+};
+
+const validateQuestions = (questions) => {
+    questions.forEach((question) => {
+        if (
+            !question ||
+            typeof question.title !== 'string' ||
+            !question.title.trim() ||
+            typeof question.type !== 'string' ||
+            !question.type.trim()
+        ) {
+            throw new AppError('Cada pregunta debe incluir title y type', 400);
+        }
+        if (question.id !== undefined && (!Number.isInteger(question.id) || question.id <= 0)) {
+            throw new AppError('ID de pregunta inválido', 400);
+        }
+        if (question.options !== undefined && !Array.isArray(question.options)) {
+            throw new AppError('options debe ser un array', 400);
+        }
+    });
+};
+
+const encodeInstanceField = (instance, field) => {
+    if (instance?.dataValues?.[field] !== undefined) {
+        instance.dataValues[field] = Utils.encode(instance.dataValues[field]);
+    }
+};
+
+const getAllComentCards = async (req, res, next) => {
     try {
         const result = await ComentCardService.getAll();
-        if (result instanceof Array) {
-            result.map((x) => {
-                x.dataValues.id = Utils.encode(x.dataValues.id);
-                x.dataValues.cardId = Utils.encode(x.dataValues.cardId);
-                x.dataValues.yachtId = Utils.encode(x.dataValues.yachtId);
-            });
-        }
+        result.forEach((cardYacht) => {
+            encodeInstanceField(cardYacht, 'id');
+            encodeInstanceField(cardYacht, 'cardId');
+            encodeInstanceField(cardYacht, 'yachtId');
+        });
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-const getComentCard = async (req, res) => {
+const getComentCard = async (req, res, next) => {
     try {
-        const formId = Utils.decode(req.params.card_id);
+        const formId = decodeId(req.params.card_id, 'ID de comment card');
         const result = await ComentCardService.getComentCardById(formId);
-        if (result instanceof Object) {
-            result.dataValues.id = Utils.encode(result.dataValues.id);
-            result.dataValues.yates.map(item => (
-                item.yate.dataValues.id = Utils.encode(item.yate.dataValues.id)
-            ))
+        if (!result) {
+            throw new AppError('Comment card no encontrada', 404);
         }
+
+        encodeInstanceField(result, 'id');
+        result.yates.forEach((item) => encodeInstanceField(item.yate, 'id'));
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-const createComentCard = async (req, res) => {
+const createComentCard = async (req, res, next) => {
     try {
-        const data = req.body;
-        await ComentCardService.createComentCard(data);
+        const { name, preguntas } = req.body;
+        if (typeof name !== 'string' || !name.trim() || !Array.isArray(preguntas)) {
+            throw new AppError('name y preguntas son obligatorios', 400);
+        }
+        validateQuestions(preguntas);
+
+        await ComentCardService.createComentCard({ name: name.trim(), preguntas });
         res.status(200).json({ data: 'resource created successfully' });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
-}
+};
 
-const updateComentCard = async (req, res) => {
+const updateComentCard = async (req, res, next) => {
     try {
-        const formId = Utils.decode(req.params.card_id);
+        const formId = decodeId(req.params.card_id, 'ID de comment card');
         const { preguntas, name } = req.body;
-        await ComentCardService.updateComentCard({ preguntas, name, formId });
+        if (typeof name !== 'string' || !name.trim() || !Array.isArray(preguntas)) {
+            throw new AppError('name y preguntas son obligatorios', 400);
+        }
+        validateQuestions(preguntas);
 
+        const existing = await ComentCardService.getComentCardById(formId);
+        if (!existing) {
+            throw new AppError('Comment card no encontrada', 404);
+        }
+        const existingQuestionIds = new Set(existing.preguntas.map((question) => question.id));
+        if (preguntas.some((question) => question.id && !existingQuestionIds.has(question.id))) {
+            throw new AppError('Una pregunta no pertenece a la comment card', 400);
+        }
+
+        await ComentCardService.updateComentCard({
+            preguntas,
+            name: name.trim(),
+            formId,
+        });
         res.status(200).json({ data: 'resource updated successfully' });
     } catch (error) {
-        console.log(error)
-        res.status(400).json(error.message);
+        next(error);
     }
-}
+};
 
-const deleteComentCard = async (req, res) => {
+const deleteComentCard = async (req, res, next) => {
     try {
-        const formId = Utils.decode(req.params.card_id);
-        const result = await ComentCardService.delete({
-            where: { id: formId }
-        });
-        res.status(200).json({ data: 'resource deleted successfully' })
+        const formId = decodeId(req.params.card_id, 'ID de comment card');
+        const deleted = await ComentCardService.delete(formId);
+        if (!deleted) {
+            throw new AppError('Comment card no encontrada', 404);
+        }
+        res.status(200).json({ data: 'resource deleted successfully' });
     } catch (error) {
-
-        res.status(400).json(error.message);
+        next(error);
     }
-}
+};
 
-// YACHT COMMENT CARD
-
-const getYachtsWithComentCard = async (req, res) => {
+const getYachtsWithComentCard = async (req, res, next) => {
     try {
-        const cardId = Utils.decode(req.params.card_id);
+        const cardId = decodeId(req.params.card_id, 'ID de comment card');
         const result = await ComentCardService.getYachtsWithComentCard(cardId);
-        if (result instanceof Array) {
-            result.map((x) => {
-                x.dataValues.id = Utils.encode(x.dataValues.id);
-                x.dataValues.yate.dataValues.id = Utils.encode(x.dataValues.yate.dataValues.id);
-            });
-        }
+        result.forEach((cardYacht) => {
+            encodeInstanceField(cardYacht, 'id');
+            encodeInstanceField(cardYacht.yate, 'id');
+        });
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-const getAllAccessLinks = async (req, res) => {
+const getAllAccessLinks = async (req, res, next) => {
     try {
-        const cardyachtId = Utils.decode(req.params.card_yacht_id);
-        const result = await ComentCardService.getAllAccessLinks(cardyachtId);
-        if (result instanceof Array) {
-            result.map((x) => {
-                x.dataValues.id = Utils.encode(x.dataValues.id);
-            });
-        }
+        const cardYachtId = decodeId(req.params.card_yacht_id, 'ID de relación comment card/yate');
+        const result = await ComentCardService.getAllAccessLinks(cardYachtId);
+        result.forEach((accessLink) => encodeInstanceField(accessLink, 'id'));
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-const getAllComentCardsForLink = async (req, res) => {
+const getAllComentCardsForLink = async (req, res, next) => {
     try {
-        const cardQrId = Utils.decode(req.params.link_id);
+        const cardQrId = decodeId(req.params.link_id, 'ID de link');
         const result = await ComentCardService.getAllComentCardsForLink(cardQrId);
-        if (result instanceof Array) {
-            result.map((x) => {
-                x.id = Utils.encode(x.id);
-            });
-        }
+        result.forEach((response) => {
+            response.id = Utils.encode(response.id);
+        });
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-//public access link
-const getComentCardByQr = async (req, res) => {
+const getComentCardByQr = async (req, res, next) => {
     try {
-        const qr = Utils.decode(req.params.comet_card_qr);
-        const result = await ComentCardService.getComentCardByQr(qr);
-        if (result instanceof Object) {
-            result.dataValues.id = Utils.encode(result.dataValues.id);
+        const qrId = decodeId(req.params.comet_card_qr, 'ID de QR');
+        const result = await ComentCardService.getComentCardByQr(qrId);
+        if (!result) {
+            throw new AppError('Link de comment card no encontrado', 404);
         }
+        encodeInstanceField(result, 'id');
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-const getComentCardByDates = async (req, res) => {
+const getComentCardByDates = async (req, res, next) => {
     try {
-        const yachtId = Utils.decode(req.params.yacht_id);
-        const { toDay } = req.query;
+        const yachtId = decodeId(req.params.yacht_id, 'ID de yate');
+        const toDay = requireValidDate(req.query.toDay, 'Fecha');
         const result = await ComentCardService.getComentCardByDates(yachtId, toDay);
+        if (!result) {
+            throw new AppError('Link de comment card no encontrado para la fecha indicada', 404);
+        }
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-const respondComentCard = async (req, res) => {
+const respondComentCard = async (req, res, next) => {
     try {
-        const cometCardQr = Utils.decode(req.params.comet_card_qr);
+        const cardQrId = decodeId(req.params.comet_card_qr, 'ID de QR');
         const { answers, cabin, name, readPolitics } = req.body;
-        const passenger = { name, cabin, readPolitics, cometCardQr };
+        if (!answers || typeof answers !== 'object' || Array.isArray(answers)) {
+            throw new AppError('answers debe ser un objeto', 400);
+        }
+        if (typeof name !== 'string' || !name.trim() || cabin === undefined || cabin === null) {
+            throw new AppError('name y cabin son obligatorios', 400);
+        }
 
-        const responsesToInsert = Object.entries(answers).map(([questionId, answer]) => {
-            if (answer !== null && answer !== undefined) {
-                return {
-                    questionId: Number(questionId),
-                    answer,
-                };
-            }
-            return null;
-        })
-            .filter(Boolean);
+        const accessLink = await ComentCardService.getComentCardByQr(cardQrId);
+        if (!accessLink) {
+            throw new AppError('Link de comment card no encontrado', 404);
+        }
 
-        await ComentCardService.respondComentCard({ responsesToInsert, passenger });
+        const responsesToInsert = Object.entries(answers)
+            .filter(([, answer]) => answer !== null && answer !== undefined)
+            .map(([questionId, answer]) => {
+                const parsedQuestionId = Number(questionId);
+                if (!Number.isInteger(parsedQuestionId) || parsedQuestionId <= 0) {
+                    throw new AppError('ID de pregunta inválido', 400);
+                }
+                return { questionId: parsedQuestionId, answer };
+            });
+        const allowedQuestionIds = new Set(
+            accessLink.card_yacht.coment_card.preguntas.map((question) => question.id)
+        );
+        if (responsesToInsert.some(({ questionId }) => !allowedQuestionIds.has(questionId))) {
+            throw new AppError('Una pregunta no pertenece a la comment card', 400);
+        }
+
+        await ComentCardService.respondComentCard({
+            responsesToInsert,
+            passenger: {
+                name: name.trim(),
+                cabin,
+                readPolitics,
+                cardQrId,
+            },
+        });
         res.status(200).json({ data: 'resource created successfully' });
     } catch (error) {
-        console.log(error)
-        res.status(400).json(error.message);
+        next(error);
     }
-}
+};
 
-const getReportingByYacht = async (req, res) => {
+const getReportingByYacht = async (req, res, next) => {
     try {
-        const yachtId = Utils.decode(req.params.yacht_id);
-        const startDate = req.query.startDate;
-        const endDate = req.query.endDate;
-        const result = await ComentCardService.getReportingByYacht(yachtId, startDate, endDate);
+        const yachtId = decodeOptionalId(req.params.yacht_id, 'ID de yate');
+        const { startDate, endDate } = req.query;
+        const hasStartDate = Boolean(startDate && startDate !== 'undefined' && startDate !== 'null');
+        const hasEndDate = Boolean(endDate && endDate !== 'undefined' && endDate !== 'null');
+
+        if (hasStartDate !== hasEndDate) {
+            throw new AppError('startDate y endDate deben enviarse juntos', 400);
+        }
+        if (hasStartDate) {
+            requireValidDate(startDate, 'startDate');
+            requireValidDate(endDate, 'endDate');
+        }
+
+        const result = await ComentCardService.getReportingByYacht(
+            yachtId,
+            hasStartDate ? startDate : undefined,
+            hasEndDate ? endDate : undefined
+        );
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
-}
+};
 
-
-
-const ComentCardController = {
+module.exports = {
     getAllComentCards,
     getComentCard,
     createComentCard,
@@ -196,6 +293,5 @@ const ComentCardController = {
     getComentCardByQr,
     getComentCardByDates,
     getReportingByYacht,
-    respondComentCard
-}
-module.exports = ComentCardController
+    respondComentCard,
+};

--- a/src/routes/operations/comentCard/comentCard.routes.js
+++ b/src/routes/operations/comentCard/comentCard.routes.js
@@ -4,22 +4,397 @@ const authJwt = require('../../../middlewares/auth.middleware');
 
 const router = Router();
 
+/**
+ * @openapi
+ * /coment_cards:
+ *   get:
+ *     summary: Listar asignaciones de comment cards a yates
+ *     tags: [Comment Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de asignaciones con sus comment cards y yates
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/', authJwt.verifyToken, ComentCardController.getAllComentCards);
+
+/**
+ * @openapi
+ * /coment_cards/{card_id}:
+ *   get:
+ *     summary: Obtener una comment card
+ *     tags: [Comment Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: card_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado de la comment card
+ *     responses:
+ *       200:
+ *         description: Comment card con preguntas y yates
+ *       400:
+ *         description: ID inválido
+ *       404:
+ *         description: Comment card no encontrada
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/:card_id', authJwt.verifyToken, ComentCardController.getComentCard);
+
+/**
+ * @openapi
+ * /coment_cards/createComentCard:
+ *   post:
+ *     summary: Crear una comment card
+ *     tags: [Comment Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name, preguntas]
+ *             properties:
+ *               name:
+ *                 type: string
+ *               preguntas:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   required: [title, type]
+ *                   properties:
+ *                     title:
+ *                       type: string
+ *                     type:
+ *                       type: string
+ *                     required:
+ *                       type: boolean
+ *                     scaleMin:
+ *                       type: integer
+ *                       nullable: true
+ *                     scaleMax:
+ *                       type: integer
+ *                       nullable: true
+ *                     options:
+ *                       type: array
+ *                       items: {}
+ *     responses:
+ *       200:
+ *         description: Comment card creada
+ *       400:
+ *         description: Payload inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.post('/createComentCard', authJwt.verifyToken, ComentCardController.createComentCard);
+
+/**
+ * @openapi
+ * /coment_cards/updateComentCard/{card_id}:
+ *   put:
+ *     summary: Actualizar una comment card y sus preguntas
+ *     tags: [Comment Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: card_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado de la comment card
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name, preguntas]
+ *             properties:
+ *               name:
+ *                 type: string
+ *               preguntas:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   required: [title, type]
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       description: ID numérico de una pregunta existente; omitir para crearla
+ *                     title:
+ *                       type: string
+ *                     type:
+ *                       type: string
+ *                     required:
+ *                       type: boolean
+ *                     scaleMin:
+ *                       type: integer
+ *                       nullable: true
+ *                     scaleMax:
+ *                       type: integer
+ *                       nullable: true
+ *                     options:
+ *                       type: array
+ *                       items: {}
+ *     responses:
+ *       200:
+ *         description: Comment card actualizada
+ *       400:
+ *         description: ID o payload inválido
+ *       404:
+ *         description: Comment card no encontrada
+ *       500:
+ *         description: Error inesperado
+ */
 router.put('/updateComentCard/:card_id', authJwt.verifyToken, ComentCardController.updateComentCard);
+
+/**
+ * @openapi
+ * /coment_cards/{card_id}:
+ *   delete:
+ *     summary: Eliminar una comment card
+ *     tags: [Comment Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: card_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado de la comment card
+ *     responses:
+ *       200:
+ *         description: Comment card eliminada
+ *       400:
+ *         description: ID inválido
+ *       404:
+ *         description: Comment card no encontrada
+ *       500:
+ *         description: Error inesperado
+ */
 router.delete('/:card_id', authJwt.verifyToken, ComentCardController.deleteComentCard);
 
-//COMMENTCARD YACHT
+/**
+ * @openapi
+ * /coment_cards/{card_id}/cards_yachts/yachts:
+ *   get:
+ *     summary: Listar yates asignados a una comment card
+ *     tags: [Comment Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: card_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado de la comment card
+ *     responses:
+ *       200:
+ *         description: Lista de asignaciones a yates
+ *       400:
+ *         description: ID inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/:card_id/cards_yachts/yachts', authJwt.verifyToken, ComentCardController.getYachtsWithComentCard);
+
+/**
+ * @openapi
+ * /coment_cards/access_links/relation/{card_yacht_id}:
+ *   get:
+ *     summary: Listar links y respuestas de una asignación comment card/yate
+ *     tags: [Comment Cards]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: card_yacht_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado de la asignación
+ *     responses:
+ *       200:
+ *         description: Lista de links de acceso
+ *       400:
+ *         description: ID inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/access_links/relation/:card_yacht_id', ComentCardController.getAllAccessLinks);
+
+/**
+ * @openapi
+ * /coment_cards/coment_cards_link/{link_id}:
+ *   get:
+ *     summary: Listar respuestas enviadas mediante un link
+ *     tags: [Comment Cards]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: link_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado del link
+ *     responses:
+ *       200:
+ *         description: Respuestas con sus preguntas, ordenadas por ID de pregunta
+ *       400:
+ *         description: ID inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/coment_cards_link/:link_id', ComentCardController.getAllComentCardsForLink);
 
-//PUBLIC ACCESS LINK
+/**
+ * @openapi
+ * /coment_cards/coment_card_by_yacht/dates/{yacht_id}:
+ *   get:
+ *     summary: Obtener el link activo de un yate para una fecha
+ *     tags: [Comment Cards]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: yacht_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado del yate
+ *       - in: query
+ *         name: toDay
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *     responses:
+ *       200:
+ *         description: Link activo
+ *       400:
+ *         description: ID o fecha inválida
+ *       404:
+ *         description: No existe un link para la fecha
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/coment_card_by_yacht/dates/:yacht_id', ComentCardController.getComentCardByDates);
+
+/**
+ * @openapi
+ * /coment_cards/coment_card_by_qr/{comet_card_qr}:
+ *   get:
+ *     summary: Obtener el formulario público mediante un QR
+ *     tags: [Comment Cards]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: comet_card_qr
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado del QR
+ *     responses:
+ *       200:
+ *         description: Comment card pública con sus preguntas
+ *       400:
+ *         description: ID inválido
+ *       404:
+ *         description: Link no encontrado
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/coment_card_by_qr/:comet_card_qr', ComentCardController.getComentCardByQr);
+
+/**
+ * @openapi
+ * /coment_cards/respond_coment_card/{comet_card_qr}:
+ *   post:
+ *     summary: Enviar respuestas de una comment card pública
+ *     tags: [Comment Cards]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: comet_card_qr
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado del QR
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name, cabin, answers]
+ *             properties:
+ *               name:
+ *                 type: string
+ *               cabin:
+ *                 oneOf:
+ *                   - type: integer
+ *                   - type: string
+ *               readPolitics:
+ *                 type: boolean
+ *               answers:
+ *                 type: object
+ *                 additionalProperties: true
+ *                 description: Mapa questionId -> respuesta
+ *     responses:
+ *       200:
+ *         description: Respuesta registrada
+ *       400:
+ *         description: ID o payload inválido
+ *       404:
+ *         description: Link no encontrado
+ *       500:
+ *         description: Error inesperado
+ */
 router.post('/respond_coment_card/:comet_card_qr', ComentCardController.respondComentCard);
 
-//REPORTS
+/**
+ * @openapi
+ * /coment_cards/reports/{yacht_id}:
+ *   get:
+ *     summary: Consultar respuestas para reportes por yate y fechas
+ *     tags: [Comment Cards]
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: yacht_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID codificado del yate; admite "undefined" para todos
+ *       - in: query
+ *         name: startDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: query
+ *         name: endDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *     responses:
+ *       200:
+ *         description: Respuestas para el reporte
+ *       400:
+ *         description: ID o rango de fechas inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/reports/:yacht_id', ComentCardController.getReportingByYacht);
+
 module.exports = router;

--- a/src/services/operations/comentCard/comentCard.services.js
+++ b/src/services/operations/comentCard/comentCard.services.js
@@ -7,94 +7,74 @@ const ComentCardAnswers = require('../../../models/operations/comentCard/comentC
 const ComentCardQuestions = require('../../../models/operations/comentCard/comentCardQuestions.models');
 const ComentCardRespond = require('../../../models/operations/comentCard/comentCardRespond.models');
 const db = require('../../../utils/database');
-require('dotenv').config();
 
+const questionPayload = (question, comentCardId) => ({
+    title: question.title,
+    type: question.type,
+    required: Boolean(question.required),
+    scaleMin: question.scaleMin ?? null,
+    scaleMax: question.scaleMax ?? null,
+    options: Array.isArray(question.options) ? question.options : [],
+    comentCardId,
+});
 
 class ComentCardService {
-    static async getAll() {
-        try {
-            const result = await ComentCardYacht.findAll({
-                include: [
-                    {
-                        model: ComentCard,
-                        as: 'coment_card',
-                    },
-                    {
+    static getAll() {
+        return ComentCardYacht.findAll({
+            include: [
+                {
+                    model: ComentCard,
+                    as: 'coment_card',
+                },
+                {
+                    model: Yacht,
+                    as: 'yate',
+                },
+            ],
+        });
+    }
+
+    static getComentCardById(id) {
+        return ComentCard.findOne({
+            where: { id },
+            attributes: ['id', 'name', 'createdAt'],
+            include: [
+                {
+                    model: ComentCardQuestions,
+                    as: 'preguntas',
+                },
+                {
+                    model: ComentCardYacht,
+                    as: 'yates',
+                    attributes: ['id'],
+                    include: [{
                         model: Yacht,
                         as: 'yate',
-                    }
-                ]
-            });
-            return result;
-        } catch (error) {
-            throw error;
-        }
+                        attributes: ['id', 'name'],
+                    }],
+                },
+            ],
+        });
     }
 
-    static async getComentCardById(id) {
-        try {
-            const result = await ComentCard.findOne({
-                where: { id },
-                attributes: ['id', 'name', 'createdAt'],
-                include: [
-                    {
-                        model: ComentCardQuestions,
-                        as: 'preguntas',
-                    },
-                    {
-                        model: ComentCardYacht,
-                        as: 'yates',
-                        attributes: ['id'],
-                        include: [{
-                            model: Yacht,
-                            as: 'yate',
-                            attributes: ['id', 'name']
-                        }]
-                    }
-                ]
-            });
-            return result;
-        } catch (error) {
-            throw error;
-        }
-    }
-
-    static async createComentCard(data) {
-        const transaction = await db.transaction();
-        try {
-            const result = await ComentCard.create(data, { transaction });
-
-            if (!result) {
-                throw new Error('No se pudo crear coment card');
+    static createComentCard(data) {
+        return db.transaction(async (transaction) => {
+            const comentCard = await ComentCard.create(
+                { name: data.name },
+                { transaction }
+            );
+            const questions = data.preguntas.map((question) =>
+                questionPayload(question, comentCard.id)
+            );
+            if (questions.length) {
+                await ComentCardQuestions.bulkCreate(questions, { transaction });
             }
-
-            const questions = data.preguntas.map(pregunta => {
-                const opciones = Array.isArray(pregunta.options)
-                    ? pregunta.options
-                    : [];
-
-                return {
-                    ...pregunta,
-                    comentCardId: result.id,
-                    opciones
-                };
-            });
-
-            await ComentCardQuestions.bulkCreate(questions, { transaction });
-
-            await transaction.commit();
-            return result;
-        } catch (error) {
-            await transaction.rollback();
-            throw new Error(error.message);
-        }
+            return comentCard;
+        });
     }
 
-    static async updateComentCard(info) {
-        const { preguntas = [], name, formId } = info;
-        const transaction = await db.transaction();
-
-        try {
+    static updateComentCard({ preguntas = [], name, formId }) {
+        return db.transaction(async (transaction) => {
             await ComentCard.update(
                 { name },
                 {
@@ -103,320 +83,244 @@ class ComentCardService {
                 }
             );
 
-            await Promise.all(
-                preguntas.map(async (pregunta) => {
-                    const opciones = Array.isArray(pregunta.options)
-                        ? pregunta.options
-                        : [];
-
-                    const payload = {
-                        title: pregunta.title,
-                        type: pregunta.type,
-                        required: pregunta.required,
-                        opciones,
+            await Promise.all(preguntas.map((question) => {
+                const payload = questionPayload(question, formId);
+                if (!question.id) {
+                    return ComentCardQuestions.create(payload, { transaction });
+                }
+                return ComentCardQuestions.update(payload, {
+                    where: {
+                        id: question.id,
                         comentCardId: formId,
-                    };
-
-                    if (!pregunta.id) {
-                        return ComentCardQuestions.create(payload, { transaction });
-                    }
-
-                    return ComentCardQuestions.update(
-                        payload,
-                        {
-                            where: { id: pregunta.id },
-                            transaction,
-                        }
-                    );
-                })
-            );
-            await transaction.commit();
+                    },
+                    transaction,
+                });
+            }));
             return true;
-        } catch (error) {
-            await transaction.rollback();
-            throw error;
-        }
+        });
     }
 
-
-    static async delete(id) {
-        try {
-            const result = await ComentCard.destroy(id);
-            return result;
-        } catch (error) {
-            throw error;
-        }
+    static delete(id) {
+        return ComentCard.destroy({ where: { id } });
     }
 
-    // COMMENT CARD YACHT
-    static async getYachtsWithComentCard(cardId) {
-        try {
-            const result = await ComentCardYacht.findAll({
-                where: { cardId },
-                attributes: ['id', 'createdAt'],
-                include: [
-                    {
-                        model: Yacht,
-                        as: 'yate',
-                        attributes: ['id', 'name']
-                    },
-                    {
-                        model: ComentCardQR,
-                        as: 'links_acceso',
-                        attributes: ['id']
-                    },
-
-                ]
-            });
-            return result;
-        } catch (error) {
-            throw error;
-        }
+    static getYachtsWithComentCard(cardId) {
+        return ComentCardYacht.findAll({
+            where: { cardId },
+            attributes: ['id', 'createdAt'],
+            include: [
+                {
+                    model: Yacht,
+                    as: 'yate',
+                    attributes: ['id', 'name'],
+                },
+                {
+                    model: ComentCardQR,
+                    as: 'links_acceso',
+                    attributes: ['id'],
+                },
+            ],
+        });
     }
 
-    static async getAllAccessLinks(comentCardYachtId) {
-        try {
-            const result = await ComentCardQR.findAll({
-                where: { comentCardYachtId },
-                attributes: [
-                    'id',
-                    'access_link',
-                    'code',
-                    'name',
-                    'start_date',
-                    'end_date',
-                    'createdAt',
-                ],
-                include: [
-                    {
-                        model: ComentCardRespond,
-                        as: 'respuestas_coment_card',
-                        include: [
-                            {
-                                model: ComentCardAnswers,
-                                as: 'respuestas',
-                                include: [
-                                    {
-                                        model: ComentCardQuestions,
-                                        as: 'pregunta',
-                                    },
-                                ],
-                            },
-                        ]
-                    },
-                ],
-                order: [['start_date', 'DESC']],
-            });
-
-            return result;
-        } catch (error) {
-            throw error;
-        }
+    static getAllAccessLinks(comentCardYachtId) {
+        return ComentCardQR.findAll({
+            where: { comentCardYachtId },
+            attributes: [
+                'id',
+                'access_link',
+                'code',
+                'name',
+                'start_date',
+                'end_date',
+                'createdAt',
+            ],
+            include: [
+                {
+                    model: ComentCardRespond,
+                    as: 'respuestas_coment_card',
+                    include: [
+                        {
+                            model: ComentCardAnswers,
+                            as: 'respuestas',
+                            include: [
+                                {
+                                    model: ComentCardQuestions,
+                                    as: 'pregunta',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            order: [['start_date', 'DESC']],
+        });
     }
 
     static async getAllComentCardsForLink(cardQrId) {
-        try {
-            const result = await ComentCardRespond.findAll({
-                where: { cardQrId },
-                attributes: [
-                    'id',
-                    'nombre_completo',
-                    'cabin',
-                    'isSubmited',
-                    'createdAt',
-                ],
-                include: [
-                    {
-                        model: ComentCardAnswers,
-                        attributes: ['answer'],
-                        as: 'respuestas',
-                        include: [
-                            {
-                                model: ComentCardQuestions,
-                                attributes: ['id', 'title'],
-                                as: 'pregunta',
-                            },
-                        ],
-                    },
-                ]
-            });
-
-            // Ordenar manualmente las respuestas por el id de la pregunta
-            const orderedResult = result.map(respond => {
-                const sortedRespuestas = [...respond.respuestas].sort((a, b) => {
-                    return a.pregunta.id - b.pregunta.id;
-                });
-                return {
-                    ...respond.toJSON(),
-                    respuestas: sortedRespuestas
-                };
-            });
-            return orderedResult;
-        } catch (error) {
-            throw error;
-        }
-    }
-
-    static async getComentCardByQr(id) {
-        try {
-            const result = await ComentCardQR.findOne({
-                where: { id },
-                //attributes: ['id', 'comentCardYachtId', 'startDate'],
-                include: [
-                    {
-                        model: ComentCardYacht,
-                        as: 'card_yacht',
-                        attributes: ['id'],
-                        include: [{
-                            model: ComentCard,
-                            as: 'coment_card',
-                            attributes: ['id', 'name'],
-                            include: [{
-                                model: ComentCardQuestions,
-                                as: 'preguntas',
-                                attributes: ['id', 'title', 'type', 'required', 'scaleMin', 'scaleMax', 'options']
-                            }]
-                        }]
-                    },
-
-                ]
-            });
-
-            return result;
-        } catch (error) {
-            throw error;
-        }
-    }
-
-    static async getComentCardByDates(comentCardYachtId, toDay) {
-        const date = new Date(toDay);
-        date.setUTCHours(0, 0, 0, 0); // para evitar desfases de zona
-
-        try {
-            const result = await ComentCardQR.findOne({
-                where: {
-                    comentCardYachtId,
-                    [Op.and]: [
-                        Sequelize.where(
-                            Sequelize.literal(`DATE_ADD(start_date, INTERVAL 1 DAY)`),
-                            { [Op.lte]: date }
-                        ),
-                        { endDate: { [Op.gte]: date } }
-                    ]
-                },
-                attributes: ['accessLink', 'startDate', 'endDate'],
-                include: [
-                    {
-                        model: ComentCardYacht,
-                        as: 'card_yacht',
-                        attributes: ['id'],
-                        include: [{
-                            model: Yacht,
-                            as: 'yate',
-                            attributes: ['code'],
-                        }]
-                    },
-                ]
-            });
-
-            return result;
-        } catch (error) {
-            throw error;
-        }
-    }
-
-    static async respondComentCard(info) {
-        const { responsesToInsert, passenger } = info;
-        const transaction = await db.transaction();
-        try {
-            const result = await ComentCardRespond.create(
+        const result = await ComentCardRespond.findAll({
+            where: { cardQrId },
+            attributes: [
+                'id',
+                'nombre_completo',
+                'cabin',
+                'isSubmited',
+                'createdAt',
+            ],
+            include: [
                 {
-                    cardQrId: passenger.cometCardQr,
+                    model: ComentCardAnswers,
+                    attributes: ['answer'],
+                    as: 'respuestas',
+                    include: [
+                        {
+                            model: ComentCardQuestions,
+                            attributes: ['id', 'title'],
+                            as: 'pregunta',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        return result.map((response) => {
+            const plainResponse = response.toJSON();
+            plainResponse.respuestas.sort((first, second) =>
+                first.pregunta.id - second.pregunta.id
+            );
+            return plainResponse;
+        });
+    }
+
+    static getComentCardByQr(id) {
+        return ComentCardQR.findOne({
+            where: { id },
+            include: [
+                {
+                    model: ComentCardYacht,
+                    as: 'card_yacht',
+                    attributes: ['id'],
+                    include: [{
+                        model: ComentCard,
+                        as: 'coment_card',
+                        attributes: ['id', 'name'],
+                        include: [{
+                            model: ComentCardQuestions,
+                            as: 'preguntas',
+                            attributes: ['id', 'title', 'type', 'required', 'scaleMin', 'scaleMax', 'options'],
+                        }],
+                    }],
+                },
+            ],
+        });
+    }
+
+    static getComentCardByDates(yachtId, toDay) {
+        const date = new Date(toDay);
+        date.setUTCHours(0, 0, 0, 0);
+
+        return ComentCardQR.findOne({
+            where: {
+                [Op.and]: [
+                    Sequelize.where(
+                        Sequelize.literal('DATE_ADD(start_date, INTERVAL 1 DAY)'),
+                        { [Op.lte]: date }
+                    ),
+                    { endDate: { [Op.gte]: date } },
+                ],
+            },
+            attributes: ['accessLink', 'startDate', 'endDate'],
+            include: [
+                {
+                    model: ComentCardYacht,
+                    as: 'card_yacht',
+                    attributes: ['id'],
+                    where: { yachtId },
+                    required: true,
+                    include: [{
+                        model: Yacht,
+                        as: 'yate',
+                        attributes: ['code'],
+                    }],
+                },
+            ],
+        });
+    }
+
+    static respondComentCard({ responsesToInsert, passenger }) {
+        return db.transaction(async (transaction) => {
+            const response = await ComentCardRespond.create(
+                {
+                    cardQrId: passenger.cardQrId,
                     fullName: passenger.name,
                     cabin: passenger.cabin,
                     readPolitics: passenger.readPolitics,
-                    isSubmited: true
-                }, { transaction });
+                    isSubmited: true,
+                },
+                { transaction }
+            );
 
-            if (!result) {
-                throw new Error('No se pudo crear coment card');
+            if (responsesToInsert.length) {
+                await ComentCardAnswers.bulkCreate(
+                    responsesToInsert.map((answer) => ({
+                        respuestaId: response.id,
+                        ...answer,
+                    })),
+                    { transaction }
+                );
             }
-
-            await Promise.all(responsesToInsert.map((respuesta) =>
-                ComentCardAnswers.create({
-                    respuestaId: result.id,
-                    ...respuesta
-                }, { transaction })
-            ));
-
-            await transaction.commit();
-            return result;
-        } catch (error) {
-            await transaction.rollback();
-            throw new Error(error.message);
-        }
+            return response;
+        });
     }
 
-    static async getReportingByYacht(yachtId, startDate, endDate) {
-        try {
+    static getReportingByYacht(yachtId, startDate, endDate) {
+        const whereYacht = yachtId ? { yachtId } : {};
+        const whereDates = startDate && endDate
+            ? { startDate: { [Op.between]: [new Date(startDate), new Date(endDate)] } }
+            : {};
 
-            const whereYacht = {};
-            if (yachtId && yachtId !== "undefined" && yachtId !== "null") {
-                whereYacht.yachtId = yachtId;
-            }
-
-            const whereDates = {};
-            if ((startDate && (startDate !== "undefined" && startDate !== 'null')) && (endDate && (endDate !== "undefined" && endDate !== 'null'))) {
-                whereDates.startDate = {
-                    [Op.between]: [new Date(startDate), new Date(endDate)]
-                };
-            }
-
-            const result = await ComentCardRespond.findAll({
-                include: [
-                    {
-                        model: ComentCardQR,
-                        as: "coment_card",
-                        where: whereDates,
-                        required: true,
-                        attributes: ['code', 'name', 'startDate', 'endDate'],
-                        include: [
-                            {
-                                model: ComentCardYacht,
-                                as: "card_yacht",
-                                required: true,
-                                where: whereYacht,
-                                include: [
-                                    {
-                                        model: Yacht,
-                                        as: "yate",
-                                        required: true,
-                                        attributes: ['name'],
-                                    }]
-                            },]
-                    },
-                    {
-                        model: ComentCardAnswers,
-                        as: "respuestas",
-                        required: true,
-                        attributes: ['id', 'answer'],
-                        include: [
-                            {
-                                model: ComentCardQuestions,
-                                as: "pregunta",
-                                required: true,
-                                attributes: ['id', 'title'],
-                            },]
-                    },
-                ],
-            })
-            return result;
-        } catch (error) {
-            throw error;
-        }
+        return ComentCardRespond.findAll({
+            include: [
+                {
+                    model: ComentCardQR,
+                    as: 'coment_card',
+                    where: whereDates,
+                    required: true,
+                    attributes: ['code', 'name', 'startDate', 'endDate'],
+                    include: [
+                        {
+                            model: ComentCardYacht,
+                            as: 'card_yacht',
+                            required: true,
+                            where: whereYacht,
+                            include: [
+                                {
+                                    model: Yacht,
+                                    as: 'yate',
+                                    required: true,
+                                    attributes: ['name'],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    model: ComentCardAnswers,
+                    as: 'respuestas',
+                    required: true,
+                    attributes: ['id', 'answer'],
+                    include: [
+                        {
+                            model: ComentCardQuestions,
+                            as: 'pregunta',
+                            required: true,
+                            attributes: ['id', 'title'],
+                        },
+                    ],
+                },
+            ],
+        });
     }
-
-
 }
 
 module.exports = ComentCardService;

--- a/tests/domain/operations-coment-card/comentCard.test.js
+++ b/tests/domain/operations-coment-card/comentCard.test.js
@@ -1,0 +1,420 @@
+const request = require('supertest');
+const { bootTestApp, shutdownTestApp } = require('../../helpers/testApp');
+const { createAuthenticatedUser } = require('../../helpers/auth');
+const { createCompanyWithYacht } = require('../../helpers/staffFixtures');
+const ComentCard = require('../../../src/models/operations/comentCard/comentCard.models');
+const ComentCardQuestions = require('../../../src/models/operations/comentCard/comentCardQuestions.models');
+const ComentCardYacht = require('../../../src/models/operations/comentCard/cardYacht.models');
+const ComentCardQR = require('../../../src/models/operations/comentCard/cardQR.models');
+const ComentCardRespond = require('../../../src/models/operations/comentCard/comentCardRespond.models');
+const ComentCardAnswers = require('../../../src/models/operations/comentCard/comentCardAnswers.models');
+const ComentCardService = require('../../../src/services/operations/comentCard/comentCard.services');
+const Utils = require('../../../src/utils/Utils');
+
+let app;
+let token;
+let fixtureCounter = 0;
+
+const auth = (httpRequest) => httpRequest.set('Authorization', `Bearer ${token}`);
+
+const createFixture = async () => {
+    fixtureCounter += 1;
+    const suffix = `${Date.now()}-${fixtureCounter}`;
+    const { yacht } = await createCompanyWithYacht(
+        `Comment Card Company ${suffix}`,
+        `Comment Card Yacht ${suffix}`
+    );
+    const card = await ComentCard.create({ name: `Comment Card ${suffix}` });
+    const questions = await ComentCardQuestions.bulkCreate([
+        {
+            comentCardId: card.id,
+            title: 'Califique el servicio',
+            type: 'scale',
+            required: true,
+            scaleMin: 1,
+            scaleMax: 5,
+            options: [],
+        },
+        {
+            comentCardId: card.id,
+            title: '¿Qué podemos mejorar?',
+            type: 'select',
+            required: false,
+            options: ['Comida', 'Servicio'],
+        },
+    ]);
+    const cardYacht = await ComentCardYacht.create({
+        cardId: card.id,
+        yachtId: yacht.id,
+    });
+    const qr = await ComentCardQR.create({
+        comentCardYachtId: cardYacht.id,
+        accessLink: `https://example.test/comment-card/${suffix}`,
+        code: `QR-${suffix}`,
+        name: `Salida ${suffix}`,
+        startDate: new Date('2026-07-01T00:00:00.000Z'),
+        endDate: new Date('2026-07-10T23:59:59.000Z'),
+    });
+
+    return { yacht, card, questions, cardYacht, qr };
+};
+
+beforeAll(async () => {
+    app = await bootTestApp();
+    token = await createAuthenticatedUser(app);
+});
+
+afterAll(async () => {
+    await shutdownTestApp();
+});
+
+describe('operaciones/comentCard', () => {
+    it('requires authentication on the administrative list', async () => {
+        const response = await request(app).get('/api/coment_cards');
+
+        expect(response.status).toBe(403);
+    });
+
+    it('lists comment-card/yacht relations with encoded identifiers', async () => {
+        const { card, yacht, cardYacht } = await createFixture();
+
+        const response = await auth(request(app).get('/api/coment_cards'));
+
+        expect(response.status).toBe(200);
+        const found = response.body.find((item) => item.id === Utils.encode(cardYacht.id));
+        expect(found.cardId).toBe(Utils.encode(card.id));
+        expect(found.yachtId).toBe(Utils.encode(yacht.id));
+        expect(found.coment_card.name).toBe(card.name);
+        expect(found.yate.name).toBe(yacht.name);
+    });
+
+    it('returns one comment card and reports invalid or missing identifiers correctly', async () => {
+        const { card, yacht } = await createFixture();
+
+        const response = await auth(
+            request(app).get(`/api/coment_cards/${Utils.encode(card.id)}`)
+        );
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBe(Utils.encode(card.id));
+        expect(response.body.yates[0].yate.id).toBe(Utils.encode(yacht.id));
+        expect(response.body.preguntas).toHaveLength(2);
+
+        const missing = await auth(
+            request(app).get(`/api/coment_cards/${Utils.encode(999999999)}`)
+        );
+        expect(missing.status).toBe(404);
+        expect(missing.body.error.message).toBe('Comment card no encontrada');
+
+        const invalid = await auth(request(app).get('/api/coment_cards/not-a-hash'));
+        expect(invalid.status).toBe(400);
+        expect(invalid.body.error.code).toBe('AppError');
+    });
+
+    it('creates a comment card and all question fields in one transaction', async () => {
+        const name = `Created Comment Card ${Date.now()}`;
+        const response = await auth(
+            request(app)
+                .post('/api/coment_cards/createComentCard')
+                .send({
+                    name,
+                    preguntas: [{
+                        title: 'Seleccione una opción',
+                        type: 'select',
+                        required: true,
+                        scaleMin: 2,
+                        scaleMax: 8,
+                        options: ['A', 'B'],
+                    }],
+                })
+        );
+
+        expect(response.status).toBe(200);
+        const card = await ComentCard.findOne({ where: { name } });
+        const question = await ComentCardQuestions.findOne({
+            where: { comentCardId: card.id },
+        });
+        expect(question.options).toEqual(['A', 'B']);
+        expect(question.scaleMin).toBe(2);
+        expect(question.scaleMax).toBe(8);
+    });
+
+    it('rejects an invalid create payload as a business error', async () => {
+        const response = await auth(
+            request(app)
+                .post('/api/coment_cards/createComentCard')
+                .send({ name: 'Sin preguntas' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.message).toBe('name y preguntas son obligatorios');
+    });
+
+    it('rolls back the parent card when creating its questions fails', async () => {
+        const name = `Rolled Back Comment Card ${Date.now()}`;
+        const failure = jest
+            .spyOn(ComentCardQuestions, 'bulkCreate')
+            .mockRejectedValueOnce(new Error('question insert failed'));
+
+        const response = await auth(
+            request(app)
+                .post('/api/coment_cards/createComentCard')
+                .send({
+                    name,
+                    preguntas: [{
+                        title: 'Pregunta válida',
+                        type: 'text',
+                        options: [],
+                    }],
+                })
+        );
+        failure.mockRestore();
+
+        expect(response.status).toBe(500);
+        expect(await ComentCard.findOne({ where: { name } })).toBeNull();
+    });
+
+    it('updates the card and persists question options through the Sequelize attribute', async () => {
+        const { card, questions } = await createFixture();
+        const response = await auth(
+            request(app)
+                .put(`/api/coment_cards/updateComentCard/${Utils.encode(card.id)}`)
+                .send({
+                    name: 'Comment Card Actualizada',
+                    preguntas: [{
+                        id: questions[0].id,
+                        title: 'Pregunta actualizada',
+                        type: 'select',
+                        required: false,
+                        options: ['Excelente', 'Bueno'],
+                    }],
+                })
+        );
+
+        expect(response.status).toBe(200);
+        await card.reload();
+        await questions[0].reload();
+        expect(card.name).toBe('Comment Card Actualizada');
+        expect(questions[0].title).toBe('Pregunta actualizada');
+        expect(questions[0].options).toEqual(['Excelente', 'Bueno']);
+    });
+
+    it('returns 404 when updating or deleting a missing card', async () => {
+        const encodedMissingId = Utils.encode(999999999);
+        const update = await auth(
+            request(app)
+                .put(`/api/coment_cards/updateComentCard/${encodedMissingId}`)
+                .send({ name: 'No existe', preguntas: [] })
+        );
+        const deletion = await auth(
+            request(app).delete(`/api/coment_cards/${encodedMissingId}`)
+        );
+
+        expect(update.status).toBe(404);
+        expect(deletion.status).toBe(404);
+    });
+
+    it('deletes an existing card', async () => {
+        const card = await ComentCard.create({ name: `Delete ${Date.now()}` });
+
+        const response = await auth(
+            request(app).delete(`/api/coment_cards/${Utils.encode(card.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(await ComentCard.findByPk(card.id)).toBeNull();
+    });
+
+    it('lists yachts assigned to a card and their access links', async () => {
+        const { card, yacht, cardYacht, qr } = await createFixture();
+
+        const yachts = await auth(
+            request(app).get(
+                `/api/coment_cards/${Utils.encode(card.id)}/cards_yachts/yachts`
+            )
+        );
+        expect(yachts.status).toBe(200);
+        expect(yachts.body[0].id).toBe(Utils.encode(cardYacht.id));
+        expect(yachts.body[0].yate.id).toBe(Utils.encode(yacht.id));
+        expect(yachts.body[0].links_acceso[0].id).toBe(qr.id);
+
+        const links = await request(app).get(
+            `/api/coment_cards/access_links/relation/${Utils.encode(cardYacht.id)}`
+        );
+        expect(links.status).toBe(200);
+        expect(links.body[0].id).toBe(Utils.encode(qr.id));
+        expect(links.body[0].access_link).toBe(qr.accessLink);
+    });
+
+    it('lists submitted responses with answers ordered by question id', async () => {
+        const { questions, qr } = await createFixture();
+        const submitted = await ComentCardRespond.create({
+            cardQrId: qr.id,
+            fullName: 'Pasajero Uno',
+            cabin: 12,
+            isSubmited: true,
+        });
+        await ComentCardAnswers.bulkCreate([
+            {
+                respuestaId: submitted.id,
+                questionId: questions[1].id,
+                answer: 'Servicio',
+            },
+            {
+                respuestaId: submitted.id,
+                questionId: questions[0].id,
+                answer: '5',
+            },
+        ]);
+
+        const response = await request(app).get(
+            `/api/coment_cards/coment_cards_link/${Utils.encode(qr.id)}`
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body[0].id).toBe(Utils.encode(submitted.id));
+        expect(response.body[0].nombre_completo).toBe('Pasajero Uno');
+        expect(response.body[0].respuestas.map((item) => item.pregunta.id)).toEqual([
+            questions[0].id,
+            questions[1].id,
+        ]);
+    });
+
+    it('returns a public comment card by QR and a 404 for an unknown QR', async () => {
+        const { card, qr } = await createFixture();
+
+        const response = await request(app).get(
+            `/api/coment_cards/coment_card_by_qr/${Utils.encode(qr.id)}`
+        );
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBe(Utils.encode(qr.id));
+        expect(response.body.card_yacht.coment_card.id).toBe(card.id);
+
+        const missing = await request(app).get(
+            `/api/coment_cards/coment_card_by_qr/${Utils.encode(999999999)}`
+        );
+        expect(missing.status).toBe(404);
+    });
+
+    it('finds the active public link by yacht/date and validates the date', async () => {
+        // Desalinear los autoincrementos de yacht y coment_card_yacht evita
+        // que una comparación accidental contra el ID de la relación pase.
+        await createCompanyWithYacht(
+            `Unassigned Company ${Date.now()}`,
+            `Unassigned Yacht ${Date.now()}`
+        );
+        const { yacht, cardYacht, qr } = await createFixture();
+        expect(yacht.id).not.toBe(cardYacht.id);
+
+        const response = await request(app).get(
+            `/api/coment_cards/coment_card_by_yacht/dates/${Utils.encode(yacht.id)}`
+        ).query({ toDay: '2026-07-03' });
+        expect(response.status).toBe(200);
+        expect(response.body.accessLink).toBe(qr.accessLink);
+
+        const invalid = await request(app).get(
+            `/api/coment_cards/coment_card_by_yacht/dates/${Utils.encode(yacht.id)}`
+        ).query({ toDay: 'fecha-invalida' });
+        expect(invalid.status).toBe(400);
+    });
+
+    it('submits a public response atomically and rejects an unknown QR', async () => {
+        const { questions, qr } = await createFixture();
+        const response = await request(app)
+            .post(`/api/coment_cards/respond_coment_card/${Utils.encode(qr.id)}`)
+            .send({
+                name: 'Pasajera Dos',
+                cabin: 21,
+                readPolitics: true,
+                answers: {
+                    [questions[0].id]: 5,
+                    [questions[1].id]: 'Comida',
+                },
+            });
+
+        expect(response.status).toBe(200);
+        const submitted = await ComentCardRespond.findOne({
+            where: { cardQrId: qr.id, fullName: 'Pasajera Dos' },
+        });
+        const answers = await ComentCardAnswers.findAll({
+            where: { respuestaId: submitted.id },
+            order: [['questionId', 'ASC']],
+        });
+        expect(submitted.isSubmited).toBe(true);
+        expect(answers.map((answer) => answer.answer)).toEqual(['5', 'Comida']);
+
+        const missing = await request(app)
+            .post(`/api/coment_cards/respond_coment_card/${Utils.encode(999999999)}`)
+            .send({
+                name: 'Pasajero',
+                cabin: 1,
+                answers: {},
+            });
+        expect(missing.status).toBe(404);
+    });
+
+    it('rejects answers that reference a question from another comment card', async () => {
+        const first = await createFixture();
+        const second = await createFixture();
+
+        const response = await request(app)
+            .post(`/api/coment_cards/respond_coment_card/${Utils.encode(first.qr.id)}`)
+            .send({
+                name: 'Respuesta cruzada',
+                cabin: 7,
+                answers: {
+                    [second.questions[0].id]: 5,
+                },
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.message).toBe(
+            'Una pregunta no pertenece a la comment card'
+        );
+        expect(await ComentCardRespond.findOne({
+            where: { cardQrId: first.qr.id, fullName: 'Respuesta cruzada' },
+        })).toBeNull();
+    });
+
+    it('reports submitted answers by yacht/date and validates paired dates', async () => {
+        const { yacht, questions, qr } = await createFixture();
+        const submitted = await ComentCardRespond.create({
+            cardQrId: qr.id,
+            fullName: 'Reporte',
+            cabin: 30,
+            isSubmited: true,
+        });
+        await ComentCardAnswers.create({
+            respuestaId: submitted.id,
+            questionId: questions[0].id,
+            answer: '4',
+        });
+
+        const response = await request(app)
+            .get(`/api/coment_cards/reports/${Utils.encode(yacht.id)}`)
+            .query({ startDate: '2026-07-01', endDate: '2026-07-11' });
+        expect(response.status).toBe(200);
+        expect(response.body.some((item) => item.id === submitted.id)).toBe(true);
+
+        const invalid = await request(app)
+            .get(`/api/coment_cards/reports/${Utils.encode(yacht.id)}`)
+            .query({ startDate: '2026-07-01' });
+        expect(invalid.status).toBe(400);
+    });
+
+    it('delegates unexpected failures to the global 500 handler', async () => {
+        const failure = jest
+            .spyOn(ComentCardService, 'getAll')
+            .mockRejectedValueOnce(new Error('database unavailable'));
+
+        const response = await auth(request(app).get('/api/coment_cards'));
+
+        expect(response.status).toBe(500);
+        expect(response.body).toEqual({
+            error: {
+                message: 'database unavailable',
+                code: 'INTERNAL_ERROR',
+            },
+        });
+        failure.mockRestore();
+    });
+});


### PR DESCRIPTION
## Resumen
- migra los 12 endpoints de commentCard a AppError y errorHandler
- valida hashids, fechas, payloads y pertenencia de preguntas
- corrige persistencia de options y búsqueda por yacht_id
- simplifica transacciones y consultas Sequelize
- documenta los endpoints en Swagger y las convenciones reutilizables

## Verificación
- npm test: 30 suites, 121 pruebas aprobadas
- dominio commentCard: 17 pruebas aprobadas
- ESLint de los archivos modificados aprobado
- carga de rutas Swagger verificada

## Nota
El lint global conserva errores heredados fuera del dominio y no fue ampliado por este PR.