### PR TITLE
refactor: modernizar dominio downloads

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -88,7 +88,9 @@ por dominio en Fase 2. Dominios ya retrofiteados: `auth`, `staff`, `users`,
 Dominios de operaciones ya retrofiteados: `comentCard`. Dominio RRHH completo:
 `formats`, `regulations`, `trading`. Dominio `reports` retrofiteado (6
 endpoints; `GET /reports/request/:request_id` se eliminó por dead code
-irreparable, confirmado por el usuario).
+irreparable, confirmado por el usuario). Dominio `downloads` retrofiteado (7
+endpoints); se restauró `FormatService.getRequestById`, eliminado erróneamente
+como dead code mientras `downloadSolicitud` todavía lo consumía.
 
 ## Validación de identificadores codificados
 
@@ -143,6 +145,43 @@ contenido igual. Patrón ya usado en
 `src/services/operations/shippingGuide/pdfService.js` y
 `src/services/bar/cruiseReportPDF.services.js`; aplicado también en
 `src/controllers/reports/*.js`.
+
+## Descarga de archivos desde disco
+
+Todo endpoint que sirve una ruta almacenada en DB debe aplicar estas reglas
+antes de iniciar la respuesta:
+
+1. Comprobar `fs.existsSync(absolutePath)` antes de `res.download` o
+   `res.sendFile`. Un registro válido no garantiza que el archivo siga en
+   disco.
+2. `mime.lookup()` devuelve `false` para extensiones desconocidas, no `null`.
+   Usar siempre `mime.lookup(path) || 'application/octet-stream'`. No derivar
+   la extensión con `mime.extension(mime.lookup(path))`: para tipos
+   desconocidos produce `false`; preservar la extensión real con
+   `path.extname(path)`.
+3. Resolver la ruta con `path.resolve(PROJECT_ROOT, '.' + relativePath)` y
+   comprobar que el resultado permanezca estrictamente bajo `uploads/`.
+   `path.join` no protege contra traversal: colapsa `..` en silencio.
+4. El `filename` de `Content-Disposition` debe derivarse del nombre público del
+   recurso y nunca incluir el ID numérico interno.
+5. Normalizar `\\` a `/` en las rutas leídas de DB para soportar registros
+   históricos guardados desde Windows.
+6. En el callback de `res.download` o `res.sendFile`, comprobar
+   `res.headersSent` antes de llamar `next(err)`. Si los headers ya salieron,
+   no se puede responder con JSON: cerrar/destruir la conexión o delegar al
+   final handler de Express.
+
+Los helpers que coordinan `res`, `fs` y MIME pueden permanecer locales al
+controller mientras tengan un único consumidor; no son utilidades puras para
+`src/utils/`.
+
+## Eliminación de métodos aparentemente muertos
+
+Antes de eliminar un método de service por "dead code", buscar su nombre en
+todo `src/`, no solo dentro del dominio en refactor. La eliminación de
+`FormatService.getRequestById` sin revisar `downloads.controller.js` dejó
+`GET /downloads/staff/request/:request_id/download` completamente roto hasta
+que el método fue restaurado.
 
 ## Transacciones Sequelize
 

--- a/docs/superpowers/plans/2026-08-05-fase-2-downloads-plan.md
+++ b/docs/superpowers/plans/2026-08-05-fase-2-downloads-plan.md
@@ -74,7 +74,8 @@ errores.
   sanitización, backslashes y JWT ausente.
 - [x] Cubrir generación exitosa, descarga y limpieza del Excel de consumer
   cards, además de sus casos 400/404.
-- [x] Ejecutar la suite tres veces en aislamiento: 40/40 en verde.
+- [x] Ejecutar la suite tres veces en aislamiento: una corrida con 39/39 antes
+  de agregar el happy path del Excel y dos corridas finales con 40/40 en verde.
 - [x] Confirmar que no quedaron fixtures bajo `uploads/`.
 - [x] Commit `a934327`.
 
@@ -92,14 +93,21 @@ errores.
   `beforeAll` porque el pool de Sequelize estaba drenando, antes de servir la
   UI. El parseo directo de swagger-jsdoc sí confirmó los 7 paths; el fallo de
   infraestructura queda registrado para la verificación final.
-- [ ] Commit de Swagger y documentación.
+- [x] Commit de Swagger y documentación (`e6936bd`).
 
 ## Task 7: Cierre
 
-- [ ] Ejecutar `npm test` completo.
-- [ ] Ejecutar `npm run lint`.
-- [ ] Hacer verificación manual con datos reales si el entorno dispone de ellos.
-- [ ] Comprobar `git status` y ausencia de archivos temporales en `uploads/`.
+- [x] Ejecutar `npm test` completo. La suite global sigue roja por timeouts
+  preexistentes de `beforeAll`: al superar los 15 segundos, `afterAll` cierra
+  Sequelize mientras `bootTestApp` continúa y aparece el error secundario
+  `pool is draining and cannot accept work`. El smoke de Swagger sí pasó dentro
+  de la corrida global.
+- [x] Ejecutar `npm run lint`. El lint global conserva errores preexistentes en
+  dominios ajenos. El único error introducido por downloads (`no-control-regex`)
+  se corrigió; controller, middleware y rutas de downloads pasan ESLint.
+- [x] Verificar las descargas con fixtures reales de DB/disco: 40/40 pruebas de
+  dominio y 3/3 del middleware en verde tras el ajuste final del sanitizer.
+- [x] Comprobar `git status` y ausencia de archivos temporales en `uploads/`.
 - [ ] Publicar la rama y abrir PR contra `trunk`, previa confirmación por ser
   acciones externas.
 

--- a/docs/superpowers/plans/2026-08-05-fase-2-downloads-plan.md
+++ b/docs/superpowers/plans/2026-08-05-fase-2-downloads-plan.md
@@ -1,0 +1,128 @@
+# Fase 2 — Dominio Downloads — Implementation Plan
+
+**Goal:** Retrofitear los siete endpoints de `/api/downloads` al patrón
+`AppError`/`next(error)`, reparar la descarga de solicitudes de staff,
+centralizar y endurecer la descarga de archivos y cubrir el dominio con tests y
+Swagger sin cambiar métodos ni URLs públicas.
+
+**Architecture:** Un helper local `sendFileDownload` en
+`src/controllers/downloads/downloads.controller.js` implementa validación de
+ruta, containment bajo `uploads/`, existencia, MIME, filename y streaming para
+los seis archivos persistidos. `exportConsumerCardReport` conserva la
+generación temporal existente y adopta validación/clasificación central de
+errores.
+
+**Tech Stack:** Node.js, Express 4, Sequelize 6/MySQL, Jest + Supertest,
+`mime-types`, excel4node y swagger-jsdoc. Diseño:
+`docs/superpowers/specs/2026-08-05-fase-2-downloads-design.md`.
+
+## Restricciones globales
+
+- Rama `refactor/fase-2-downloads`, creada desde `trunk`.
+- No cambiar ninguna URL ni método HTTP.
+- Conservar `/cruise/:cruise_id/download/pfd` con el typo histórico.
+- Mantener JWT mediante `authJwt.verifyToken`.
+- No incluir IDs numéricos internos en filenames.
+- Usar fixtures reales solo bajo el `uploads/` ignorado y eliminarlas al final.
+- No corregir defectos encontrados en dominios ajenos.
+
+## Task 1: Restaurar `FormatService.getRequestById`
+
+- [x] Restaurar el método que consulta `RequestStaffs` por PK.
+- [x] Verificar en runtime que el método se exporte como función.
+- [x] Auditar los métodos de services consumidos por downloads.
+- [x] Registrar fuera de scope el método faltante de shipping guide.
+- [x] Commit `50486cb`.
+
+## Task 2: Proteger `errorHandler` tras iniciar una respuesta
+
+- [x] Agregar un test unitario inicialmente rojo para `headersSent`.
+- [x] Delegar a `next(err)` cuando los headers ya fueron enviados.
+- [x] Confirmar los tres tests unitarios en verde.
+- [x] Commit `1c9fa6d`.
+
+## Task 3: Consolidar los seis handlers persistidos
+
+- [x] Agregar `decodeId` local con validación de throw/`undefined`.
+- [x] Implementar sanitización del filename.
+- [x] Normalizar separadores y resolver rutas absolutas.
+- [x] Exigir containment estricto bajo `uploads/`.
+- [x] Comprobar existencia antes de iniciar la respuesta.
+- [x] Usar fallback `application/octet-stream` y `path.extname`.
+- [x] Evitar `next(error)` después de iniciar el stream.
+- [x] Retrofitear reglamentos, formatos médicos, solicitudes, guías y los dos
+  reportes de crucero.
+- [x] Conservar las seis claves públicas del controller.
+- [x] Commit `c5354ac`.
+
+## Task 4: Retrofitear `exportConsumerCardReport`
+
+- [x] Validar `yachtId` mediante hashid.
+- [x] Devolver 404 cuando el yate no existe.
+- [x] Delegar errores inesperados con `next(error)`.
+- [x] Conservar generación, descarga y borrado del archivo temporal.
+- [x] Commit `e06328f`.
+
+## Task 5: Tests de dominio
+
+- [x] Crear fixtures de DB para los seis recursos persistidos.
+- [x] Crear archivos reales bajo `uploads/__test_downloads__/`.
+- [x] Cubrir 200, 400 por hashid, 404 de recurso, 404 sin archivo y 404 de
+  archivo ausente en cada endpoint persistido.
+- [x] Cubrir la regresión de `getRequestById`.
+- [x] Cubrir MIME desconocido, extensión real, filename sin ID, traversal,
+  sanitización, backslashes y JWT ausente.
+- [x] Cubrir generación exitosa, descarga y limpieza del Excel de consumer
+  cards, además de sus casos 400/404.
+- [x] Ejecutar la suite tres veces en aislamiento: 40/40 en verde.
+- [x] Confirmar que no quedaron fixtures bajo `uploads/`.
+- [x] Commit `a934327`.
+
+## Task 6: Swagger y documentación
+
+- [x] Documentar las siete rutas con tag `Downloads`, bearer auth y respuestas
+  binarias/400/403/404.
+- [x] Documentar explícitamente que `pfd` se conserva por compatibilidad.
+- [x] Confirmar mediante swagger-jsdoc que los siete paths existen.
+- [x] Actualizar `docs/CONVENTIONS.md` con el dominio y las reglas reutilizables
+  de descarga.
+- [x] Registrar la lección de buscar en todo `src/` antes de borrar dead code.
+- [x] Guardar este plan y el documento de diseño.
+- [x] Ejecutar el smoke test de Swagger: dos intentos alcanzaron el timeout de
+  `beforeAll` porque el pool de Sequelize estaba drenando, antes de servir la
+  UI. El parseo directo de swagger-jsdoc sí confirmó los 7 paths; el fallo de
+  infraestructura queda registrado para la verificación final.
+- [ ] Commit de Swagger y documentación.
+
+## Task 7: Cierre
+
+- [ ] Ejecutar `npm test` completo.
+- [ ] Ejecutar `npm run lint`.
+- [ ] Hacer verificación manual con datos reales si el entorno dispone de ellos.
+- [ ] Comprobar `git status` y ausencia de archivos temporales en `uploads/`.
+- [ ] Publicar la rama y abrir PR contra `trunk`, previa confirmación por ser
+  acciones externas.
+
+## Contrato de errores
+
+```json
+{ "error": { "message": "mensaje", "code": "AppError|INTERNAL_ERROR" } }
+```
+
+| Caso | Status |
+|---|---:|
+| Sin autorización | 403 |
+| Hashid inválido | 400 |
+| Recurso inexistente | 404 |
+| Sin archivo asociado | 404 |
+| Path fuera de `uploads/` | 404 |
+| Archivo ausente | 404 |
+| Error inesperado | 500 |
+
+## Hallazgos fuera de alcance
+
+- Rutas de solicitudes guardadas con backslashes por `formats`.
+- `RequestStaffs` sin asociaciones/FKs inicializadas.
+- `ShippingGuideService.createItemsOfShippingGuide` invocado pero inexistente.
+- Import `cos` sin uso en consumer cards.
+- Ruta genérica de reglamentos ubicada primero en el router.

--- a/docs/superpowers/specs/2026-08-05-fase-2-downloads-design.md
+++ b/docs/superpowers/specs/2026-08-05-fase-2-downloads-design.md
@@ -98,8 +98,9 @@ archivos reales bajo `uploads/__test_downloads__/`, eliminados en `afterAll`.
 Cubre los seis downloads persistidos, el reporte Excel generado, hashids
 inválidos, recursos/archivos ausentes, MIME desconocido, filenames sin ID,
 traversal, separadores Windows, sanitización de nombres y JWT ausente. La suite
-pasó tres veces en aislamiento; el happy path del Excel también comprueba la
-firma ZIP `PK` y la eliminación del temporal.
+pasó tres veces en aislamiento: una corrida con 39 pruebas antes de agregar el
+happy path del Excel y dos corridas finales con 40 pruebas. Ese happy path
+también comprueba la firma ZIP `PK` y la eliminación del temporal.
 
 ## Hallazgos fuera de alcance
 

--- a/docs/superpowers/specs/2026-08-05-fase-2-downloads-design.md
+++ b/docs/superpowers/specs/2026-08-05-fase-2-downloads-design.md
@@ -1,0 +1,116 @@
+# Fase 2 — Dominio Downloads — diseño
+
+**Fecha:** 2026-08-05  
+**Estado:** Implementado
+
+## Contexto y alcance
+
+El dominio expone siete rutas protegidas bajo `/api/downloads`: seis sirven
+archivos existentes en disco y una genera un reporte Excel de consumer cards.
+Se conservaron todos los métodos y paths públicos, incluido el typo histórico
+`/cruise/:cruise_id/download/pfd`, requerido por compatibilidad con el front.
+
+El objetivo fue adoptar `AppError`/`next(error)`, clasificar correctamente 400,
+404 y 500, reparar la descarga de solicitudes de staff, consolidar la lógica
+de filesystem y cubrir el dominio con tests reales de DB y disco.
+
+## Diseño
+
+Los seis handlers de archivos persistidos comparten un helper local
+`sendFileDownload` en `downloads.controller.js`. El helper permanece local
+porque coordina Express (`res`), filesystem y MIME; no es una utilidad pura
+para `src/utils/`.
+
+El flujo es:
+
+1. Decodificar y validar inmediatamente el hashid con `decodeId`.
+2. Consultar el recurso y devolver 404 si no existe.
+3. Validar que tenga una ruta asociada.
+4. Normalizar separadores históricos de Windows.
+5. Resolver una ruta absoluta y exigir containment estricto bajo `uploads/`.
+6. Confirmar que el archivo exista antes de iniciar la respuesta.
+7. Elegir MIME con fallback seguro y conservar la extensión real.
+8. Descargar con un nombre público sanitizado, sin ID numérico interno.
+
+`exportConsumerCardReport` conserva su generación de archivo temporal y su
+limpieza posterior, pero ahora valida `yachtId`, devuelve 404 para un yate
+inexistente y delega errores inesperados al middleware central.
+
+## Bugs corregidos
+
+- **Solicitud de staff rota al 100%:** el commit `46a9680` eliminó
+  `FormatService.getRequestById` aunque `downloadSolicitud` seguía llamándolo.
+  Se restauró el método y se agregó una regresión de dominio.
+- **Path traversal desde datos de DB:** las rutas se confiaban y `path.join`
+  colapsaba `..`, permitiendo salir de `uploads/`. Ahora se exige containment.
+- **MIME desconocido:** `mime.lookup` devuelve `false`; el flujo anterior podía
+  enviar `Content-Type: false` y generar nombres terminados en `.false`. Ahora
+  usa `application/octet-stream` y `path.extname`.
+- **Archivos ausentes:** formato médico y solicitud no comprobaban existencia
+  antes de `res.download`. El guard aplica ahora a los seis endpoints.
+- **Errores mal clasificados:** excepciones inesperadas se aplastaban a 400 y
+  recursos inexistentes podían terminar en `TypeError`. Ahora los casos
+  identificables usan `AppError` y el resto llega como 500 centralizado.
+- **Respuesta ya iniciada:** `errorHandler` ahora delega si
+  `res.headersSent`; los callbacks de descarga no intentan escribir JSON tras
+  iniciar el stream.
+- **Fuga de IDs internos:** los filenames se derivan del nombre, counter o code
+  público del recurso.
+
+## Contrato HTTP
+
+La respuesta exitosa continúa siendo binaria. Los errores usan:
+
+```json
+{ "error": { "message": "mensaje", "code": "AppError|INTERNAL_ERROR" } }
+```
+
+| Caso | Status |
+|---|---:|
+| Token ausente o inválido | 403 |
+| Hashid inválido | 400 |
+| Recurso inexistente | 404 |
+| Recurso sin archivo asociado | 404 |
+| Ruta fuera de `uploads/` | 404 |
+| Archivo ausente en disco | 404 |
+| Error inesperado antes de headers | 500 |
+| Error de stream tras headers | conexión cerrada/delegada |
+
+## Cambios conscientes de contrato
+
+- La forma de las respuestas de error se unifica al estándar central.
+- Cuatro filenames dejan de incluir IDs numéricos o basenames internos y usan
+  el nombre público del recurso.
+- Los reportes de crucero sin archivo asociado pasan a 404, consistente con
+  los otros downloads.
+- No se corrige `pfd`; cambiarlo rompería el contrato público.
+
+## Seguridad preservada
+
+`/api/downloads` sigue protegido por `authJwt.verifyToken`, sin agregar ni
+retirar roles. El containment bajo `uploads/` es endurecimiento de filesystem,
+no un cambio de política de autorización.
+
+## Verificación
+
+`tests/domain/downloads/downloads.test.js` contiene 40 pruebas con Sequelize y
+archivos reales bajo `uploads/__test_downloads__/`, eliminados en `afterAll`.
+Cubre los seis downloads persistidos, el reporte Excel generado, hashids
+inválidos, recursos/archivos ausentes, MIME desconocido, filenames sin ID,
+traversal, separadores Windows, sanitización de nombres y JWT ausente. La suite
+pasó tres veces en aislamiento; el happy path del Excel también comprueba la
+firma ZIP `PK` y la eliminación del temporal.
+
+## Hallazgos fuera de alcance
+
+- `FormatService.createRequesForStaff` guarda rutas no portables con
+  backslashes en Windows; el lector las compensa, pero el fix real exige
+  normalizar al escribir y migrar datos (`formats`).
+- `RequestStaffs` no se registra en `src/models/init.models.js`, por lo que no
+  tiene asociaciones/FKs inicializadas (`formats`/modelado).
+- `ShippingGuideService.createItemsOfShippingGuide` es invocado por
+  `shippingGuide.controller.js` pero no existe en el service
+  (`shippingGuide`).
+- `consumerCard.controller.js` importa `cos` desde `mathjs` sin usarlo (`bar`).
+- La ruta genérica `GET /:rule_id/download` aparece primero en el router; hoy no
+  colisiona, pero una futura ruta de dos segmentos podría quedar capturada.

--- a/src/controllers/bar/consumerCard.controller.js
+++ b/src/controllers/bar/consumerCard.controller.js
@@ -11,9 +11,23 @@ const { sendBarConsumption, sendInvoiceEmail } = require('../../mails/mailer');
 const { passengerInvoicePDF } = require('../../services/bar/passengerInvoicePDF.services');
 const { generateConsumerCardReportExcel } = require('../../services/bar/consumerCardReportExcel.services');
 const Yacht = require('../../models/catalogs/yacht.models');
+const AppError = require('../../errors/AppError');
 
 // Constantes
 const UPLOADS_BASE_PATH = path.resolve(__dirname, '../../../uploads');
+
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
 
 const getAllConsumer = async (req, res) => {
     try {
@@ -261,10 +275,10 @@ const updateCortecyCard = async (req, res) => {
     }
 }
 
-const exportConsumerCardReport = async (req, res) => {
+const exportConsumerCardReport = async (req, res, next) => {
     try {
         const { year, start, end } = req.query;
-        const yachtId = Utils.decode(req.query.yachtId);
+        const yachtId = decodeId(req.query.yachtId, 'yachtId');
 
         // Obtener información del yate
         const yacht = await Yacht.findByPk(yachtId, {
@@ -272,7 +286,7 @@ const exportConsumerCardReport = async (req, res) => {
         });
 
         if (!yacht) {
-            return res.status(404).json({ error: 'Yacht not found' });
+            throw new AppError('Yate no encontrado', 404);
         }
 
         // Obtener consumer cards y cortecy cards filtradas
@@ -300,8 +314,7 @@ const exportConsumerCardReport = async (req, res) => {
         });
 
     } catch (error) {
-        console.error('Error generating report:', error);
-        res.status(400).json({ error: error.message });
+        next(error);
     }
 };
 

--- a/src/controllers/downloads/downloads.controller.js
+++ b/src/controllers/downloads/downloads.controller.js
@@ -1,173 +1,164 @@
 const RegulationService = require('../../services/rrhh/regulations.services');
 const FormatService = require('../../services/rrhh/formats.services');
 const ShippingGuideService = require('../../services/operations/shippingGuide/shippingGuide.services');
+const CruiseService = require('../../services/bar/cruise.services');
 const Utils = require('../../utils/Utils');
+const AppError = require('../../errors/AppError');
 const path = require('path');
 const fs = require('fs');
 const mime = require('mime-types');
-const CruiseService = require('../../services/bar/cruise.services');
 
-const downloadReglamento = async (req, res) => {
+const PROJECT_ROOT = path.resolve(__dirname, '../../../');
+const UPLOADS_ROOT = path.join(PROJECT_ROOT, 'uploads');
+
+const decodeId = (value, fieldName) => {
+    let id;
     try {
-        const ruleId = Utils.decode(req.params.rule_id);
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
+
+const sanitizeFilenameBase = (value) => {
+    const cleaned = String(value ?? '')
+        .replace(/[\x00-\x1f\x7f/\\?%*:|"<>]/g, '')
+        .replace(/\s+/g, '_')
+        .replace(/^[._]+|[._]+$/g, '')
+        .slice(0, 100);
+    return cleaned || 'archivo';
+};
+
+const sendFileDownload = (res, next, { relativePath, filenameBase, missingFileMessage }) => {
+    if (!relativePath) throw new AppError(missingFileMessage, 404);
+
+    // Registros historicos guardados en Windows traen backslashes.
+    const normalized = String(relativePath).replace(/\\/g, '/');
+    const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
+    const absolutePath = path.resolve(PROJECT_ROOT, `.${withLeadingSlash}`);
+
+    // path.join colapsa '..' en silencio; sin este guard un dato corrupto
+    // en DB sirve cualquier archivo del disco.
+    if (!absolutePath.startsWith(UPLOADS_ROOT + path.sep)) {
+        throw new AppError('Archivo no encontrado', 404);
+    }
+    if (!fs.existsSync(absolutePath)) {
+        throw new AppError('Archivo no encontrado', 404);
+    }
+
+    // mime.lookup devuelve false (no null) para extensiones desconocidas.
+    res.setHeader('Content-Type', mime.lookup(absolutePath) || 'application/octet-stream');
+    const extension = path.extname(absolutePath).toLowerCase();
+
+    res.download(absolutePath, `${sanitizeFilenameBase(filenameBase)}${extension}`, (err) => {
+        if (!err) return;
+        if (res.headersSent) {
+            console.error('Error enviando archivo tras iniciar la respuesta:', err);
+            return res.destroy();
+        }
+        next(err);
+    });
+};
+
+const downloadReglamento = async (req, res, next) => {
+    try {
+        const ruleId = decodeId(req.params.rule_id, 'rule_id');
         const regulation = await RegulationService.getRegulationById(ruleId);
-        const relativePath = regulation.dataValues.file;
+        if (!regulation) throw new AppError('Reglamento no encontrado', 404);
 
-        if (!relativePath) {
-            return res.status(404).json({ message: 'El reglamento no tiene archivo asociado' });
-        }
-
-        const absolutePath = path.join(__dirname, '../../../', relativePath);
-
-        if (!fs.existsSync(absolutePath)) {
-            return res.status(404).json({ message: 'Archivo no encontrado' });
-        }
-
-        const mimeType = mime.lookup(absolutePath);  // puede devolver null si no encuentra
-        const extension = mime.extension(mimeType);
-
-        const filename = `reglamento-${ruleId}.${extension}`; // o usa el nombre original si lo prefieres
-
-        res.setHeader('Content-Type', mimeType);
-        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-        res.sendFile(absolutePath);
+        sendFileDownload(res, next, {
+            relativePath: regulation.dataValues.file,
+            filenameBase: regulation.dataValues.name,
+            missingFileMessage: 'El reglamento no tiene archivo asociado',
+        });
     } catch (error) {
-        console.log(error);
-        res.status(400).json({ message: error.message });
+        next(error);
     }
 };
 
-const downloadFormato = async (req, res) => {
+const downloadFormato = async (req, res, next) => {
     try {
-        const formatId = Utils.decode(req.params.format_id);
+        const formatId = decodeId(req.params.format_id, 'format_id');
         const format = await FormatService.getDoctorFormat(formatId);
-        const relativePath = format.dataValues.file;
+        if (!format) throw new AppError('Formato médico no encontrado', 404);
 
-        if (!relativePath) {
-            return res.status(404).json({ message: 'El formato no tiene archivo asociado' });
-        }
-
-        const absolutePath = path.join(__dirname, '../../../', relativePath);
-        res.download(absolutePath, (err) => {
-            if (err) {
-                res.status(500).send('Error al descargar el archivo');
-            }
+        sendFileDownload(res, next, {
+            relativePath: format.dataValues.file,
+            filenameBase: format.dataValues.name,
+            missingFileMessage: 'El formato médico no tiene archivo asociado',
         });
     } catch (error) {
-        console.log(error);
-        res.status(400).json(error.message);
+        next(error);
     }
 };
 
-const downloadSolicitud = async (req, res) => {
+const downloadSolicitud = async (req, res, next) => {
     try {
-        const requestId = Utils.decode(req.params.request_id);
-        const format = await FormatService.getRequestById(requestId);
-        const relativePath = format.dataValues.file;
+        const requestId = decodeId(req.params.request_id, 'request_id');
+        const request = await FormatService.getRequestById(requestId);
+        if (!request) throw new AppError('Solicitud no encontrada', 404);
 
-        if (!relativePath) {
-            return res.status(404).json({ message: 'El formato no tiene archivo asociado' });
-        }
-
-        const absolutePath = path.join(__dirname, '../../../', relativePath);
-        res.download(absolutePath, (err) => {
-            if (err) {
-                console.log(err)
-                res.status(500).send('Error al descargar el archivo');
-            }
+        sendFileDownload(res, next, {
+            relativePath: request.dataValues.file,
+            filenameBase: `Solicitud_${request.dataValues.name}`,
+            missingFileMessage: 'La solicitud no tiene archivo asociado',
         });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 };
 
-const downloadGuiaRemision = async (req, res) => {
+const downloadGuiaRemision = async (req, res, next) => {
     try {
-        const guideId = Utils.decode(req.params.guide_id);
-        const regulation = await ShippingGuideService.getShippingGuideById(guideId);
-        const relativePath = regulation.dataValues.file;
+        const guideId = decodeId(req.params.guide_id, 'guide_id');
+        const guide = await ShippingGuideService.getShippingGuideById(guideId);
+        if (!guide) throw new AppError('Guía de remisión no encontrada', 404);
 
-        if (!relativePath) {
-            return res.status(404).json({ message: 'la guia no tiene archivo asociado' });
-        }
-
-        const absolutePath = path.join(__dirname, '../../../', relativePath);
-
-        if (!fs.existsSync(absolutePath)) {
-            return res.status(404).json({ message: 'Archivo no encontrado' });
-        }
-
-        const mimeType = mime.lookup(absolutePath);  // puede devolver null si no encuentra
-        const extension = mime.extension(mimeType);
-
-        const filename = `guia_remision_${regulation.counter}.${extension}`;
-
-        res.setHeader('Content-Type', mimeType);
-        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-        res.sendFile(absolutePath);
+        sendFileDownload(res, next, {
+            relativePath: guide.dataValues.file,
+            filenameBase: `guia_remision_${guide.dataValues.counter}`,
+            missingFileMessage: 'La guía de remisión no tiene archivo asociado',
+        });
     } catch (error) {
-        console.log(error);
-        res.status(400).json({ message: error.message });
+        next(error);
     }
 };
 
-const downloadreportePdf = async (req, res) => {
+const downloadreportePdf = async (req, res, next) => {
     try {
-        const cruiseid = Utils.decode(req.params.cruise_id);
-        const cruise = await CruiseService.getCruiseById(cruiseid);
-        const relativePath = cruise.urlPDFReport;
+        const cruiseId = decodeId(req.params.cruise_id, 'cruise_id');
+        // getCruiseById devuelve un objeto plano, no una instancia Sequelize.
+        const cruise = await CruiseService.getCruiseById(cruiseId);
+        if (!cruise) throw new AppError('Crucero no encontrado', 404);
 
-        if (!relativePath) {
-            throw new Error('la crucero no tiene archivo asociado');
-        }
-
-        const absolutePath = path.join(__dirname, '../../../', relativePath);
-
-        if (!fs.existsSync(absolutePath)) {
-            throw new Error('Archivo no encontrado');
-        }
-
-        const mimeType = mime.lookup(absolutePath);  // puede devolver null si no encuentra
-        const extension = mime.extension(mimeType);
-
-        const filename = `reporte_crucero_${cruise.code}.${extension}`;
-
-        res.setHeader('Content-Type', mimeType);
-        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-        res.sendFile(absolutePath);
+        sendFileDownload(res, next, {
+            relativePath: cruise.urlPDFReport,
+            filenameBase: `reporte_crucero_${cruise.code}`,
+            missingFileMessage: 'El crucero no tiene reporte PDF asociado',
+        });
     } catch (error) {
-        console.log(error);
-        res.status(400).json(error.message);
+        next(error);
     }
 };
 
-const downloadreporteExcel = async (req, res) => {
+const downloadreporteExcel = async (req, res, next) => {
     try {
-        const cruiseid = Utils.decode(req.params.cruise_id);
-        const cruise = await CruiseService.getCruiseById(cruiseid);
-        const relativePath = cruise.urlExcelReport;
+        const cruiseId = decodeId(req.params.cruise_id, 'cruise_id');
+        // getCruiseById devuelve un objeto plano, no una instancia Sequelize.
+        const cruise = await CruiseService.getCruiseById(cruiseId);
+        if (!cruise) throw new AppError('Crucero no encontrado', 404);
 
-        if (!relativePath) {
-            throw new Error('la crucero no tiene archivo asociado');
-        }
-
-        const absolutePath = path.join(__dirname, '../../../', relativePath);
-
-        if (!fs.existsSync(absolutePath)) {
-            throw new Error('Archivo no encontrado');
-        }
-
-        const mimeType = mime.lookup(absolutePath);  // puede devolver null si no encuentra
-        const extension = mime.extension(mimeType);
-
-        const filename = `reporte_crucero_${cruise.code}.${extension}`;
-
-        res.setHeader('Content-Type', mimeType);
-        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-        res.sendFile(absolutePath);
+        sendFileDownload(res, next, {
+            relativePath: cruise.urlExcelReport,
+            filenameBase: `reporte_crucero_${cruise.code}`,
+            missingFileMessage: 'El crucero no tiene reporte Excel asociado',
+        });
     } catch (error) {
-        console.log(error);
-        res.status(400).json(error.message);
+        next(error);
     }
 };
 

--- a/src/controllers/downloads/downloads.controller.js
+++ b/src/controllers/downloads/downloads.controller.js
@@ -25,8 +25,14 @@ const decodeId = (value, fieldName) => {
 };
 
 const sanitizeFilenameBase = (value) => {
-    const cleaned = String(value ?? '')
-        .replace(/[\x00-\x1f\x7f/\\?%*:|"<>]/g, '')
+    const invalidFilenameChars = '/\\?%*:|"<>';
+    const withoutInvalidChars = Array.from(String(value ?? ''))
+        .filter((character) => {
+            const code = character.charCodeAt(0);
+            return code > 31 && code !== 127 && !invalidFilenameChars.includes(character);
+        })
+        .join('');
+    const cleaned = withoutInvalidChars
         .replace(/\s+/g, '_')
         .replace(/^[._]+|[._]+$/g, '')
         .slice(0, 100);

--- a/src/middlewares/errorHandler.middleware.js
+++ b/src/middlewares/errorHandler.middleware.js
@@ -1,6 +1,15 @@
 const AppError = require('../errors/AppError');
 
 const errorHandler = (err, req, res, next) => {
+    // Un error posterior al inicio de la respuesta (streams de descarga, por
+    // ejemplo) no se puede reportar en el body: res.status() lanzaria
+    // ERR_HTTP_HEADERS_SENT. Se delega al finalHandler de Express, que cierra
+    // la conexion.
+    if (res.headersSent) {
+        console.error('Error tras enviar headers:', err);
+        return next(err);
+    }
+
     const statusCode = err instanceof AppError ? err.statusCode : 500;
     const code = err instanceof AppError ? err.name : 'INTERNAL_ERROR';
 

--- a/src/routes/downloads/downloads.routes.js
+++ b/src/routes/downloads/downloads.routes.js
@@ -4,15 +4,245 @@ const ConsumerCardController = require('../../controllers/bar/consumerCard.contr
 
 const router = Router();
 
+/**
+ * @openapi
+ * /downloads/{rule_id}/download:
+ *   get:
+ *     summary: Descargar el archivo de un reglamento
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: rule_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de reglamento codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Archivo del reglamento
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Reglamento inexistente, sin archivo asociado o con archivo ausente en disco
+ */
 router.get('/:rule_id/download', DownloadController.downloadReglamento);
+
+/**
+ * @openapi
+ * /downloads/guide/{guide_id}/download:
+ *   get:
+ *     summary: Descargar el archivo de una guía de remisión
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: guide_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de guía de remisión codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Archivo de la guía de remisión
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Guía inexistente, sin archivo asociado o con archivo ausente en disco
+ */
 router.get('/guide/:guide_id/download', DownloadController.downloadGuiaRemision);
+
+/**
+ * @openapi
+ * /downloads/doctor_format/{format_id}/download:
+ *   get:
+ *     summary: Descargar el archivo de un formato médico
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: format_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de formato médico codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Archivo del formato médico
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Formato inexistente, sin archivo asociado o con archivo ausente en disco
+ */
 router.get('/doctor_format/:format_id/download', DownloadController.downloadFormato);
+
+/**
+ * @openapi
+ * /downloads/staff/request/{request_id}/download:
+ *   get:
+ *     summary: Descargar una solicitud de staff
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: request_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de solicitud codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Archivo de la solicitud
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Solicitud inexistente, sin archivo asociado o con archivo ausente en disco
+ */
 router.get('/staff/request/:request_id/download', DownloadController.downloadSolicitud);
-//bar
+
+/**
+ * @openapi
+ * /downloads/cruise/{cruise_id}/download/pfd:
+ *   get:
+ *     summary: "Descargar el reporte PDF de un crucero (nota: 'pfd' es un typo histórico en la URL pública; se conserva por compatibilidad con el front)"
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cruise_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de crucero codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Reporte PDF del crucero
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Crucero inexistente, sin reporte asociado o con archivo ausente en disco
+ */
 router.get('/cruise/:cruise_id/download/pfd', DownloadController.downloadreportePdf);
+
+/**
+ * @openapi
+ * /downloads/cruise/{cruise_id}/download/excel:
+ *   get:
+ *     summary: Descargar el reporte Excel de un crucero
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cruise_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de crucero codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Reporte Excel del crucero
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Crucero inexistente, sin reporte asociado o con archivo ausente en disco
+ */
 router.get('/cruise/:cruise_id/download/excel', DownloadController.downloadreporteExcel);
+
+/**
+ * @openapi
+ * /downloads/consumer-cards/export/report:
+ *   get:
+ *     summary: Generar y descargar el reporte Excel de consumer cards de un yate
+ *     tags: [Downloads]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: yachtId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de yate codificado (hashids)
+ *       - in: query
+ *         name: year
+ *         schema:
+ *           type: integer
+ *         description: Año de creación de las tarjetas
+ *       - in: query
+ *         name: start
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Fecha inicial del rango de cruceros
+ *       - in: query
+ *         name: end
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Fecha final del rango de cruceros
+ *     responses:
+ *       200:
+ *         description: Reporte Excel generado
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: ID de yate codificado inválido
+ *       403:
+ *         description: Token ausente o inválido
+ *       404:
+ *         description: Yate no encontrado
+ */
 router.get('/consumer-cards/export/report', ConsumerCardController.exportConsumerCardReport);
-
-
 
 module.exports = router;

--- a/src/services/rrhh/formats.services.js
+++ b/src/services/rrhh/formats.services.js
@@ -125,12 +125,7 @@ class FormatService {
     }
 
     static async getRequestById(requestId) {
-        try {
-            const result = await RequestStaffs.findOne({ where: { id: requestId } });
-            return result;
-        } catch (error) {
-            throw error;
-        }
+        return RequestStaffs.findOne({ where: { id: requestId } });
     }
 
     static async createRequesForStaff(data) {

--- a/src/services/rrhh/formats.services.js
+++ b/src/services/rrhh/formats.services.js
@@ -124,6 +124,15 @@ class FormatService {
         }
     }
 
+    static async getRequestById(requestId) {
+        try {
+            const result = await RequestStaffs.findOne({ where: { id: requestId } });
+            return result;
+        } catch (error) {
+            throw error;
+        }
+    }
+
     static async createRequesForStaff(data) {
         try {
             const { compania, yate, name, formatId, staffId, file } = data;

--- a/tests/domain/downloads/downloads.test.js
+++ b/tests/domain/downloads/downloads.test.js
@@ -1,0 +1,560 @@
+const fs = require('fs');
+const path = require('path');
+const request = require('supertest');
+const { bootTestApp, shutdownTestApp } = require('../../helpers/testApp');
+const { createAuthenticatedUser } = require('../../helpers/auth');
+const { createDepartment, createPosition, createCompanyWithYacht } = require('../../helpers/staffFixtures');
+const Staff = require('../../../src/models/catalogs/staff.models');
+const Regulation = require('../../../src/models/rrhh/regulation.models');
+const DoctorFormat = require('../../../src/models/rrhh/doctorFormat.models');
+const Format = require('../../../src/models/rrhh/format.models');
+const RequestStaffs = require('../../../src/models/rrhh/requestStaffs.models');
+const ShippingGuide = require('../../../src/models/operations/shippingGuide/shippingGuide.models');
+const Cruise = require('../../../src/models/bar/cruises.models');
+const Utils = require('../../../src/utils/Utils');
+
+let app;
+let token;
+let fixtureCounter = 0;
+
+const auth = (httpRequest) => httpRequest.set('Authorization', `Bearer ${token}`);
+const suffix = () => {
+    fixtureCounter += 1;
+    return `${Date.now()}-${fixtureCounter}`;
+};
+
+// El helper valida containment bajo uploads/, asi que un os.tmpdir() seria
+// rechazado. uploads/ esta en .gitignore.
+const FIXTURE_DIR_NAME = `__test_downloads__/${process.pid}-${Date.now()}`;
+const FIXTURE_ABS_DIR = path.join(__dirname, '../../..', 'uploads', FIXTURE_DIR_NAME);
+
+// Separadores POSIX a mano: path.relative devolveria backslashes en Windows,
+// y ese caso se prueba aparte a proposito.
+const createFixtureFile = (filename, contents = 'FIXTURE-CONTENT') => {
+    fs.mkdirSync(FIXTURE_ABS_DIR, { recursive: true });
+    fs.writeFileSync(path.join(FIXTURE_ABS_DIR, filename), contents);
+    return `/uploads/${FIXTURE_DIR_NAME}/${filename}`;
+};
+
+const missingFilePath = (filename) => `/uploads/${FIXTURE_DIR_NAME}/${filename}`;
+
+const readBinary = (httpRequest) =>
+    httpRequest.buffer(true).parse((res, callback) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+    });
+
+const waitForFileRemoval = async (filePath) => {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (!fs.existsSync(filePath)) return;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`El archivo temporal no fue eliminado: ${filePath}`);
+};
+
+beforeAll(async () => {
+    app = await bootTestApp();
+    token = await createAuthenticatedUser(app);
+}, 60000);
+
+afterAll(async () => {
+    fs.rmSync(FIXTURE_ABS_DIR, { recursive: true, force: true });
+    await shutdownTestApp();
+});
+
+// --- Fixtures de DB -------------------------------------------------------
+
+async function createRegulationFixture(file) {
+    const { company } = await createCompanyWithYacht(`Reg Company ${suffix()}`);
+    return Regulation.create({
+        name: `Reglamento Interno ${suffix()}`,
+        file,
+        companyId: company.id,
+    });
+}
+
+async function createDoctorFormatFixture(file) {
+    return DoctorFormat.create({
+        name: `Formato Medico ${suffix()}`,
+        file,
+        companies: [],
+    });
+}
+
+async function createRequestFixture(file) {
+    const departament = await createDepartment();
+    const position = await createPosition();
+    const uniqueSuffix = suffix();
+    const staff = await Staff.create({
+        firstName: 'TEST_AUTOMATED',
+        lastName: `Downloads${uniqueSuffix}`,
+        email: `downloads-test-${uniqueSuffix}@example.com`,
+        cellPhone: '0966666666',
+        password: 'Sup3rSecret!',
+        departamentId: departament.id,
+        positionId: position.id,
+        contractType: 'Fijo',
+        active: true,
+    });
+    const format = await Format.create({
+        name: `Formato ${uniqueSuffix}`,
+        content: '<p>contenido</p>',
+        companies: [],
+    });
+    return RequestStaffs.create({
+        formatId: format.id,
+        staffId: staff.id,
+        name: `Vacaciones ${uniqueSuffix}`,
+        company: 'Rolf Wittmer',
+        file,
+    });
+}
+
+async function createShippingGuideFixture(file) {
+    return ShippingGuide.create({
+        counter: `001-${suffix()}`,
+        dateStartTraslate: new Date('2026-07-01'),
+        dateEndTraslate: new Date('2026-07-02'),
+        file,
+    });
+}
+
+async function createCruiseFixture(overrides = {}) {
+    const { yacht } = await createCompanyWithYacht(`Cruise Company ${suffix()}`);
+    return Cruise.create({
+        yachtId: yacht.id,
+        code: `CR-${suffix()}`,
+        name: `Crucero ${suffix()}`,
+        itinerary: 'A',
+        transferDay: 1,
+        startDate: new Date('2026-07-01'),
+        endDate: new Date('2026-07-08'),
+        ...overrides,
+    });
+}
+
+// --- Los 6 endpoints, 5 casos cada uno ------------------------------------
+
+describe('Downloads — reglamento', () => {
+    const url = (id) => `/api/downloads/${id}/download`;
+
+    it('descarga el archivo del reglamento', async () => {
+        const file = createFixtureFile(`reglamento-${suffix()}.pdf`);
+        const regulation = await createRegulationFixture(file);
+
+        const response = await auth(request(app).get(url(Utils.encode(regulation.id))));
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('Reglamento_Interno');
+        expect(response.headers['content-type']).toContain('application/pdf');
+    });
+
+    it('devuelve 400 con un hashid invalido', async () => {
+        const response = await auth(request(app).get(url('not-a-hashid')));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si el reglamento no existe', async () => {
+        const response = await auth(request(app).get(url(Utils.encode(999999999))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Reglamento no encontrado');
+    });
+
+    it('devuelve 404 si no tiene archivo asociado', async () => {
+        const regulation = await createRegulationFixture('');
+
+        const response = await auth(request(app).get(url(Utils.encode(regulation.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('El reglamento no tiene archivo asociado');
+    });
+
+    it('devuelve 404 si el archivo no esta en disco', async () => {
+        const regulation = await createRegulationFixture(missingFilePath('nunca-creado.pdf'));
+
+        const response = await auth(request(app).get(url(Utils.encode(regulation.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Archivo no encontrado');
+    });
+});
+
+describe('Downloads — formato medico', () => {
+    const url = (id) => `/api/downloads/doctor_format/${id}/download`;
+
+    it('descarga el archivo del formato medico', async () => {
+        const file = createFixtureFile(`formato-${suffix()}.pdf`);
+        const format = await createDoctorFormatFixture(file);
+
+        const response = await auth(request(app).get(url(Utils.encode(format.id))));
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('Formato_Medico');
+    });
+
+    it('devuelve 400 con un hashid invalido', async () => {
+        const response = await auth(request(app).get(url('not-a-hashid')));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si el formato no existe', async () => {
+        const response = await auth(request(app).get(url(Utils.encode(999999999))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Formato médico no encontrado');
+    });
+
+    it('devuelve 404 si no tiene archivo asociado', async () => {
+        const format = await createDoctorFormatFixture(null);
+
+        const response = await auth(request(app).get(url(Utils.encode(format.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('El formato médico no tiene archivo asociado');
+    });
+
+    it('devuelve 404 si el archivo no esta en disco', async () => {
+        const format = await createDoctorFormatFixture(missingFilePath('nunca-creado.pdf'));
+
+        const response = await auth(request(app).get(url(Utils.encode(format.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Archivo no encontrado');
+    });
+});
+
+describe('Downloads — solicitud de staff', () => {
+    const url = (id) => `/api/downloads/staff/request/${id}/download`;
+
+    // Regresion: 46a9680 borro FormatService.getRequestById como dead code
+    // mientras este handler seguia llamandola, dejando el endpoint 100% roto.
+    it('descarga la solicitud (regresion del bug de 46a9680)', async () => {
+        const file = createFixtureFile(`solicitud-${suffix()}.pdf`);
+        const requestRow = await createRequestFixture(file);
+
+        const response = await auth(request(app).get(url(Utils.encode(requestRow.id))));
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('Solicitud_Vacaciones');
+    });
+
+    it('devuelve 400 con un hashid invalido', async () => {
+        const response = await auth(request(app).get(url('not-a-hashid')));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si la solicitud no existe', async () => {
+        const response = await auth(request(app).get(url(Utils.encode(999999999))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Solicitud no encontrada');
+    });
+
+    it('devuelve 404 si no tiene archivo asociado', async () => {
+        const requestRow = await createRequestFixture(null);
+
+        const response = await auth(request(app).get(url(Utils.encode(requestRow.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('La solicitud no tiene archivo asociado');
+    });
+
+    it('devuelve 404 si el archivo no esta en disco', async () => {
+        const requestRow = await createRequestFixture(missingFilePath('nunca-creado.pdf'));
+
+        const response = await auth(request(app).get(url(Utils.encode(requestRow.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Archivo no encontrado');
+    });
+});
+
+describe('Downloads — guia de remision', () => {
+    const url = (id) => `/api/downloads/guide/${id}/download`;
+
+    it('descarga el archivo de la guia', async () => {
+        const file = createFixtureFile(`guia-${suffix()}.pdf`);
+        const guide = await createShippingGuideFixture(file);
+
+        const response = await auth(request(app).get(url(Utils.encode(guide.id))));
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('guia_remision_001-');
+    });
+
+    it('devuelve 400 con un hashid invalido', async () => {
+        const response = await auth(request(app).get(url('not-a-hashid')));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si la guia no existe', async () => {
+        const response = await auth(request(app).get(url(Utils.encode(999999999))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Guía de remisión no encontrada');
+    });
+
+    it('devuelve 404 si no tiene archivo asociado', async () => {
+        const guide = await createShippingGuideFixture('');
+
+        const response = await auth(request(app).get(url(Utils.encode(guide.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('La guía de remisión no tiene archivo asociado');
+    });
+
+    it('devuelve 404 si el archivo no esta en disco', async () => {
+        const guide = await createShippingGuideFixture(missingFilePath('nunca-creado.pdf'));
+
+        const response = await auth(request(app).get(url(Utils.encode(guide.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Archivo no encontrado');
+    });
+});
+
+describe('Downloads — reporte PDF de crucero', () => {
+    // 'pfd' es un typo historico en la URL publica; se conserva a proposito.
+    const url = (id) => `/api/downloads/cruise/${id}/download/pfd`;
+
+    it('descarga el reporte PDF', async () => {
+        const file = createFixtureFile(`crucero-pdf-${suffix()}.pdf`);
+        const cruise = await createCruiseFixture({ urlPDFReport: file });
+
+        const response = await auth(request(app).get(url(Utils.encode(cruise.id))));
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('reporte_crucero_CR-');
+    });
+
+    it('devuelve 400 con un hashid invalido', async () => {
+        const response = await auth(request(app).get(url('not-a-hashid')));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si el crucero no existe', async () => {
+        const response = await auth(request(app).get(url(Utils.encode(999999999))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Crucero no encontrado');
+    });
+
+    it('devuelve 404 si no tiene reporte PDF asociado', async () => {
+        const cruise = await createCruiseFixture({ urlPDFReport: null });
+
+        const response = await auth(request(app).get(url(Utils.encode(cruise.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('El crucero no tiene reporte PDF asociado');
+    });
+
+    it('devuelve 404 si el archivo no esta en disco', async () => {
+        const cruise = await createCruiseFixture({ urlPDFReport: missingFilePath('nunca-creado.pdf') });
+
+        const response = await auth(request(app).get(url(Utils.encode(cruise.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Archivo no encontrado');
+    });
+});
+
+describe('Downloads — reporte Excel de crucero', () => {
+    const url = (id) => `/api/downloads/cruise/${id}/download/excel`;
+
+    it('descarga el reporte Excel', async () => {
+        const file = createFixtureFile(`crucero-excel-${suffix()}.xlsx`);
+        const cruise = await createCruiseFixture({ urlExcelReport: file });
+
+        const response = await auth(request(app).get(url(Utils.encode(cruise.id))));
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('reporte_crucero_CR-');
+    });
+
+    it('devuelve 400 con un hashid invalido', async () => {
+        const response = await auth(request(app).get(url('not-a-hashid')));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si el crucero no existe', async () => {
+        const response = await auth(request(app).get(url(Utils.encode(999999999))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Crucero no encontrado');
+    });
+
+    it('devuelve 404 si no tiene reporte Excel asociado', async () => {
+        const cruise = await createCruiseFixture({ urlExcelReport: null });
+
+        const response = await auth(request(app).get(url(Utils.encode(cruise.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('El crucero no tiene reporte Excel asociado');
+    });
+
+    it('devuelve 404 si el archivo no esta en disco', async () => {
+        const cruise = await createCruiseFixture({ urlExcelReport: missingFilePath('nunca-creado.pdf') });
+
+        const response = await auth(request(app).get(url(Utils.encode(cruise.id))));
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Archivo no encontrado');
+    });
+});
+
+// --- Regresiones que justifican el dominio --------------------------------
+
+describe('Downloads — regresiones del helper', () => {
+    it('usa application/octet-stream para una extension desconocida, nunca .false', async () => {
+        const file = createFixtureFile(`raro-${suffix()}.zzz`);
+        const regulation = await createRegulationFixture(file);
+
+        const response = await auth(
+            request(app).get(`/api/downloads/${Utils.encode(regulation.id)}/download`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toContain('application/octet-stream');
+        expect(response.headers['content-disposition']).toContain('.zzz');
+        expect(response.headers['content-disposition']).not.toContain('false');
+    });
+
+    it('no filtra el id numerico interno en el filename', async () => {
+        const file = createFixtureFile(`sin-id-${suffix()}.pdf`);
+        const regulation = await createRegulationFixture(file);
+
+        const response = await auth(
+            request(app).get(`/api/downloads/${Utils.encode(regulation.id)}/download`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).not.toContain(`reglamento-${regulation.id}`);
+    });
+
+    it('rechaza path traversal con 404 y no sirve el archivo', async () => {
+        const regulation = await createRegulationFixture('/../../package.json');
+
+        const response = await readBinary(
+            auth(request(app).get(`/api/downloads/${Utils.encode(regulation.id)}/download`))
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.toString()).not.toContain('"dependencies"');
+    });
+
+    it('rechaza una ruta que escapa de uploads/ dentro del proyecto', async () => {
+        const regulation = await createRegulationFixture('/uploads/../package.json');
+
+        const response = await readBinary(
+            auth(request(app).get(`/api/downloads/${Utils.encode(regulation.id)}/download`))
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.toString()).not.toContain('"dependencies"');
+    });
+
+    it('no revienta con un nombre que trae comillas y saltos de linea', async () => {
+        const file = createFixtureFile(`comillas-${suffix()}.pdf`);
+        const { company } = await createCompanyWithYacht(`Quote Company ${suffix()}`);
+        const regulation = await Regulation.create({
+            name: 'Regla "rara"\nsegunda linea',
+            file,
+            companyId: company.id,
+        });
+
+        const response = await auth(
+            request(app).get(`/api/downloads/${Utils.encode(regulation.id)}/download`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).not.toContain('\n');
+    });
+
+    it('resuelve rutas guardadas con separadores de Windows', async () => {
+        const filename = `windows-${suffix()}.pdf`;
+        createFixtureFile(filename);
+        const windowsPath = `/uploads/${FIXTURE_DIR_NAME}/${filename}`.replace(/\//g, '\\');
+        const regulation = await createRegulationFixture(windowsPath);
+
+        const response = await auth(
+            request(app).get(`/api/downloads/${Utils.encode(regulation.id)}/download`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+    });
+
+    it('responde 403 sin token', async () => {
+        const response = await request(app).get(`/api/downloads/${Utils.encode(1)}/download`);
+
+        expect(response.status).toBe(403);
+    });
+});
+
+describe('Downloads — reporte de consumer cards', () => {
+    const url = '/api/downloads/consumer-cards/export/report';
+
+    it('genera, descarga y elimina el reporte Excel', async () => {
+        const { yacht } = await createCompanyWithYacht(
+            `Report Company ${suffix()}`,
+            `Yate Reporte ${suffix()}`
+        );
+        const reportPath = path.join(
+            __dirname,
+            '../../..',
+            'uploads',
+            'reports',
+            `consumer_report_${yacht.name}.xlsx`
+        );
+
+        const response = await readBinary(
+            auth(request(app).get(url).query({ yachtId: Utils.encode(yacht.id) }))
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-disposition']).toContain('attachment');
+        expect(response.headers['content-disposition']).toContain('consumer_report_Yate Reporte');
+        expect(response.headers['content-type']).toContain(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        );
+        expect(response.body.subarray(0, 2).toString()).toBe('PK');
+        await waitForFileRemoval(reportPath);
+    });
+
+    it('devuelve 400 con un yachtId invalido', async () => {
+        const response = await auth(request(app).get(url).query({ yachtId: 'not-a-hashid' }));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 si el yate no existe', async () => {
+        const response = await auth(
+            request(app).get(url).query({ yachtId: Utils.encode(999999999) })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.message).toBe('Yate no encontrado');
+    });
+});

--- a/tests/unit/middlewares/errorHandler.test.js
+++ b/tests/unit/middlewares/errorHandler.test.js
@@ -5,6 +5,7 @@ function mockRes() {
     return {
         statusCode: null,
         body: null,
+        headersSent: false,
         status(code) { this.statusCode = code; return this; },
         json(payload) { this.body = payload; return this; },
     };
@@ -29,5 +30,17 @@ describe('errorHandler middleware', () => {
 
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({ error: { message: 'boom', code: 'INTERNAL_ERROR' } });
+    });
+
+    it('delega a next cuando los headers ya se enviaron', () => {
+        const res = mockRes();
+        res.headersSent = true;
+        res.json = () => { throw new Error('no debe responder'); };
+        const next = jest.fn();
+
+        errorHandler(new Error('boom'), {}, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.statusCode).toBeNull();
     });
 });


### PR DESCRIPTION
## Resumen

- Retrofitea los 7 endpoints de `/api/downloads` al patrón `AppError` / `next(error)` sin cambiar métodos ni URLs públicas.
- Conserva el typo histórico `/cruise/:cruise_id/download/pfd` por compatibilidad con el frontend.
- Consolida los 6 downloads persistidos en un helper local con validación de filesystem, MIME y filename.
- Incluye el reporte Excel de consumer cards, Swagger y convenciones reutilizables.

## Bugs corregidos

- Restaura `FormatService.getRequestById`, cuya eliminación en `46a9680` dejó completamente roto el download de solicitudes de staff.
- Clasifica hashids inválidos como 400 y recursos/archivos ausentes como 404.
- Evita path traversal y exige containment estricto bajo `uploads/`.
- Verifica la existencia del archivo antes de iniciar la respuesta.
- Usa `application/octet-stream` para MIME desconocido y conserva la extensión real, evitando nombres `.false`.
- Elimina IDs numéricos internos de los filenames descargados.
- Soporta rutas históricas guardadas con backslashes de Windows.
- Evita respuestas JSON después de iniciar un stream (`ERR_HTTP_HEADERS_SENT`).

## Cambios conscientes de contrato

- Los errores adoptan `{ \"error\": { \"message\", \"code\" } }`.
- Los filenames se derivan del nombre público, counter o code del recurso y no del ID interno.
- Los reportes de crucero sin archivo asociado responden 404.

## Verificación

- `tests/domain/downloads/downloads.test.js`: **40/40** en verde con Sequelize y archivos reales.
- `tests/unit/middlewares/errorHandler.test.js`: **3/3** en verde.
- Total focalizado final: **43/43**.
- Swagger UI pasó dentro de la corrida global y `swagger-jsdoc` confirmó los 7 paths.
- Controller, middleware y rutas centrales de downloads pasan ESLint.
- Sin fixtures ni reportes temporales residuales en `uploads/`.
- Working tree limpio.

## Incidencias preexistentes

- `npm test -- --runInBand` global sigue rojo por timeouts de `beforeAll`: al superar 15 segundos, el teardown cierra Sequelize mientras `bootTestApp` continúa y aparece `pool is draining and cannot accept work`.
- `npm run lint` global conserva numerosos errores en dominios ajenos al refactor. El único error introducido inicialmente por downloads (`no-control-regex`) fue corregido.

## Fuera de alcance

- Normalización al escribir de rutas de solicitudes guardadas con backslashes.
- Asociaciones/FKs faltantes de `RequestStaffs`.
- `ShippingGuideService.createItemsOfShippingGuide` invocado pero inexistente.
- Imports y warnings legados del dominio `bar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)