### PR TITLE
refactor: completar fase 2 de orders

### DIFF
--- a/src/controllers/operations/orders/orders.controller.js
+++ b/src/controllers/operations/orders/orders.controller.js
@@ -85,18 +85,17 @@ const createOrder = async (req, res) => {
     }
 }
 
-const updateOrder = async (req, res) => {
+const updateOrder = async (req, res, next) => {
     try {
-        const orderId = Utils.decode(req.params.order_id);
-        const data = req.body
-        await OrderService.updateOrder(data, {
-            where: { id: orderId }
+        const orderId = decodeId(req.params.order_id, 'order_id');
+        const data = req.body;
+        const [affectedRows] = await OrderService.updateOrder(data, {
+            where: { id: orderId },
         });
-
+        if (affectedRows === 0) throw new AppError('Orden no encontrada', 404);
         res.status(200).json({ data: 'resource updated successfully' });
     } catch (error) {
-
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/controllers/operations/orders/orders.controller.js
+++ b/src/controllers/operations/orders/orders.controller.js
@@ -99,13 +99,14 @@ const updateOrder = async (req, res, next) => {
     }
 }
 
-const deleteItem = async (req, res) => {
+const deleteItem = async (req, res, next) => {
     try {
-        const itemId = Utils.decode(req.params.item_id);
+        const itemId = decodeId(req.params.item_id, 'item_id');
         const result = await OrderService.deleteItem(itemId);
-        res.status(200).json({ data: result })
+        if (!result) throw new AppError('Item no encontrado', 404);
+        res.status(200).json({ data: result });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/operations/orders/orders.controller.js
+++ b/src/controllers/operations/orders/orders.controller.js
@@ -4,6 +4,20 @@ const CompanyService = require('../../../services/catalogs/company.services');
 const XLSX = require('xlsx');
 const { sendEmailNewOrder, sendConfirmationEmail, sendDispatchEmail } = require('../../../mails/mailer');
 const Staffervice = require('../../../services/catalogs/staff.services');
+const AppError = require('../../../errors/AppError');
+
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
 
 const getAllOrders = async (req, res) => {
     try {
@@ -20,17 +34,15 @@ const getAllOrders = async (req, res) => {
     }
 }
 
-const getOrderById = async (req, res) => {
+const getOrderById = async (req, res, next) => {
     try {
-        const orderId = Utils.decode(req.params.order_id);
-        const result = await OrderService.getOrderById(orderId)
-        if (result instanceof Object) {
-            result.id = Utils.encode(result.id);
-        }
+        const orderId = decodeId(req.params.order_id, 'order_id');
+        const result = await OrderService.getOrderById(orderId);
+        if (!result) throw new AppError('Orden no encontrada', 404);
+        result.id = Utils.encode(result.id);
         res.status(200).json(result);
     } catch (error) {
-
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/controllers/operations/orders/orders.controller.js
+++ b/src/controllers/operations/orders/orders.controller.js
@@ -19,7 +19,7 @@ const decodeId = (value, fieldName) => {
     return id;
 };
 
-const getAllOrders = async (req, res) => {
+const getAllOrders = async (req, res, next) => {
     try {
         const result = await OrderService.getAllOrders();
         if (result instanceof Array) {
@@ -30,7 +30,7 @@ const getAllOrders = async (req, res) => {
         }
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 
@@ -46,13 +46,14 @@ const getOrderById = async (req, res, next) => {
     }
 }
 
-const createOrder = async (req, res) => {
+const createOrder = async (req, res, next) => {
     try {
-        const data = req.body;
-        data.companyId = Utils.decode(data.companyId)
-        data.userId = Utils.decode(data.userId)
+        if (!req.file) throw new AppError('Archivo Excel requerido', 400);
 
-        const file = req.file;
+        const data = req.body;
+        data.companyId = decodeId(data.companyId, 'companyId');
+        data.userId = decodeId(data.userId, 'userId');
+
         const fieldMapping = {
             'sku': 'sku',
             'product': 'product',
@@ -60,7 +61,7 @@ const createOrder = async (req, res) => {
             'originalQuantity': 'originalQuantity',
         };
 
-        const workbook = XLSX.readFile(file.path);
+        const workbook = XLSX.readFile(req.file.path);
         const sheet_name_list = workbook.SheetNames;
         const jsonData = XLSX.utils.sheet_to_json(workbook.Sheets[sheet_name_list[0]]);
         const mappedData = jsonData.map(row => {
@@ -74,14 +75,14 @@ const createOrder = async (req, res) => {
 
         await OrderService.createOrder(data, mappedData);
 
-        const company = await CompanyService.getCompanyById(data.companyId)
-        const staff = await Staffervice.getStaffById(data.userId)
-        action = 'pedido'
+        const company = await CompanyService.getCompanyById(data.companyId);
+        const staff = await Staffervice.getStaffById(data.userId);
+        const action = 'pedido';
         sendEmailNewOrder(company.name);
-        sendConfirmationEmail(action, company.name, staff)
+        sendConfirmationEmail(action, company.name, staff);
         res.status(200).json({ data: 'resource created successfully' });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/reports/generateGeneralReportEvaluations.js
+++ b/src/controllers/reports/generateGeneralReportEvaluations.js
@@ -63,7 +63,7 @@ const generateGeneralReportEvaluations = async (req, res, next) => {
 
         const dateStyle = wb.createStyle({
             font: { color: "#000000" },
-            numberFormat: "dd-mmm-yyyy",
+            numberFormat: "dd/mm/yyyy",
         });
 
         const formTitleStyles = colors.map(color =>

--- a/src/routes/operations/orders/order.routes.js
+++ b/src/routes/operations/orders/order.routes.js
@@ -4,12 +4,187 @@ const { uploadExcelFile } = require('../../../utils/uploadConfiguration');
 
 const router = Router();
 
+/**
+ * @openapi
+ * /orders:
+ *   get:
+ *     summary: Listar todas las órdenes
+ *     tags: [Orders]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de órdenes con su empresa, responsable e items
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     description: ID de orden codificado (hashids)
+ *                   companyId:
+ *                     type: string
+ *                     description: ID de empresa codificado (hashids)
+ *                   name:
+ *                     type: string
+ *                     nullable: true
+ *                   status:
+ *                     type: string
+ *                   guide:
+ *                     type: string
+ *                     nullable: true
+ *                   company:
+ *                     type: object
+ *                   responsible:
+ *                     type: object
+ *                   orderItems:
+ *                     type: array
+ *                     items:
+ *                       type: object
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       500:
+ *         description: Error inesperado
+ *   post:
+ *     summary: Crear una orden a partir de un archivo Excel
+ *     tags: [Orders]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required: [companyId, userId, status, file]
+ *             properties:
+ *               companyId:
+ *                 type: string
+ *                 description: ID de empresa codificado (hashids)
+ *               userId:
+ *                 type: string
+ *                 description: ID de responsable codificado (hashids)
+ *               name:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *               guide:
+ *                 type: string
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *                 description: Archivo Excel con columnas sku, product, quantity y originalQuantity
+ *     responses:
+ *       200:
+ *         description: Orden creada
+ *       400:
+ *         description: Archivo Excel requerido o ID codificado inválido
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/',OrderController.getAllOrders);
+
+/**
+ * @openapi
+ * /orders/{order_id}:
+ *   get:
+ *     summary: Obtener una orden por ID
+ *     tags: [Orders]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: order_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de orden codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Orden encontrada con su empresa e items
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       404:
+ *         description: Orden no encontrada
+ *       500:
+ *         description: Error inesperado
+ *   put:
+ *     summary: Actualizar una orden
+ *     tags: [Orders]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: order_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de orden codificado (hashids)
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *               guide:
+ *                 type: string
+ *                 nullable: true
+ *     responses:
+ *       200:
+ *         description: Orden actualizada
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       404:
+ *         description: Orden no encontrada
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/:order_id',OrderController.getOrderById);
 router.post('/', uploadExcelFile, OrderController.createOrder);
 router.put('/:order_id', OrderController.updateOrder);
 
 //ITEMS ORDER
+/**
+ * @openapi
+ * /orders/deleteItem/{item_id}:
+ *   delete:
+ *     summary: Eliminar un item de una orden
+ *     tags: [Orders]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: item_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID del item codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Item eliminado
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       404:
+ *         description: Item no encontrado
+ *       500:
+ *         description: Error inesperado
+ */
 router.delete('/deleteItem/:item_id', OrderController.deleteItem);
 
 module.exports = router;

--- a/tests/domain/operations-orders/orders.test.js
+++ b/tests/domain/operations-orders/orders.test.js
@@ -180,3 +180,41 @@ describe('PUT /api/orders/:order_id — actualizar orden', () => {
         expect(response.status).toBe(403);
     });
 });
+
+describe('DELETE /api/orders/deleteItem/:item_id — eliminar item', () => {
+    it('devuelve 200 al eliminar el item', async () => {
+        const order = await createOrderFixture();
+        const item = await createOrderItemFixture(order.id);
+
+        const response = await auth(
+            request(app).delete(`/api/orders/deleteItem/${Utils.encode(item.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource deleted successfully');
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).delete('/api/orders/deleteItem/not-a-hashid')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el item no existe', async () => {
+        const response = await auth(
+            request(app).delete(`/api/orders/deleteItem/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).delete('/api/orders/deleteItem/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-orders/orders.test.js
+++ b/tests/domain/operations-orders/orders.test.js
@@ -137,3 +137,46 @@ describe('GET /api/orders/:order_id — orden por ID', () => {
         expect(response.status).toBe(403);
     });
 });
+
+describe('PUT /api/orders/:order_id — actualizar orden', () => {
+    it('devuelve 200 al actualizar la orden', async () => {
+        const order = await createOrderFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/orders/${Utils.encode(order.id)}`)
+                .send({ status: 'procesado' })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource updated successfully');
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).put('/api/orders/not-a-hashid').send({ status: 'procesado' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando la orden no existe', async () => {
+        const response = await auth(
+            request(app)
+                .put(`/api/orders/${Utils.encode(999999)}`)
+                .send({ status: 'procesado' })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app)
+            .put('/api/orders/any-id')
+            .send({});
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-orders/orders.test.js
+++ b/tests/domain/operations-orders/orders.test.js
@@ -1,0 +1,102 @@
+jest.mock('../../../src/mails/mailer', () => ({
+    sendEmailNewOrder: jest.fn(),
+    sendConfirmationEmail: jest.fn(),
+    sendDispatchEmail: jest.fn(),
+}));
+
+const request = require('supertest');
+const XLSX = require('xlsx');
+const { bootTestApp, shutdownTestApp } = require('../../helpers/testApp');
+const { createAuthenticatedUser } = require('../../helpers/auth');
+const { createDepartment, createPosition, createCompanyWithYacht } = require('../../helpers/staffFixtures');
+const Staff = require('../../../src/models/catalogs/staff.models');
+const Order = require('../../../src/models/operations/orders/order.models');
+const orderItems = require('../../../src/models/operations/orders/orderItems.models');
+const Utils = require('../../../src/utils/Utils');
+
+let app;
+let token;
+let fixtureCounter = 0;
+
+const auth = (httpRequest) => httpRequest.set('Authorization', `Bearer ${token}`);
+const suffix = () => {
+    fixtureCounter += 1;
+    return `${Date.now()}-${fixtureCounter}`;
+};
+
+beforeAll(async () => {
+    app = await bootTestApp();
+    token = await createAuthenticatedUser(app);
+}, 60000);
+
+afterAll(async () => {
+    await shutdownTestApp();
+});
+
+async function createStaffFixture() {
+    const dept = await createDepartment(`Dept-${suffix()}`);
+    const pos = await createPosition(`Pos-${suffix()}`);
+    const s = suffix();
+    return Staff.create({
+        firstName: 'TEST',
+        lastName: `Orders${s}`,
+        email: `orders-test-${s}@example.com`,
+        cellPhone: '0966666666',
+        password: 'Sup3rSecret!',
+        departamentId: dept.id,
+        positionId: pos.id,
+        contractType: 'Fijo',
+        active: true,
+    });
+}
+
+async function createOrderFixture(overrides = {}) {
+    const { company } = await createCompanyWithYacht(`Order Company ${suffix()}`);
+    const staff = await createStaffFixture();
+    return Order.create({
+        companyId: company.id,
+        userId: staff.id,
+        name: `Pedido-${suffix()}`,
+        status: 'en espera',
+        guide: `GUIDE-${suffix()}`,
+        ...overrides,
+    });
+}
+
+async function createOrderItemFixture(orderId, overrides = {}) {
+    return orderItems.create({
+        orderId,
+        product: `Producto-${suffix()}`,
+        sku: `SKU-${suffix()}`,
+        quantity: 10,
+        originalQuantity: 10,
+        status: 'en espera',
+        ...overrides,
+    });
+}
+
+function createExcelBuffer() {
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.json_to_sheet([
+        { sku: 'SKU-001', product: 'Producto Test', quantity: 5, originalQuantity: 5 },
+    ]);
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+}
+
+describe('GET /api/orders — lista de órdenes', () => {
+    it('devuelve 200 con la lista de órdenes', async () => {
+        await createOrderFixture();
+
+        const response = await auth(request(app).get('/api/orders'));
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/orders');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-orders/orders.test.js
+++ b/tests/domain/operations-orders/orders.test.js
@@ -100,3 +100,40 @@ describe('GET /api/orders — lista de órdenes', () => {
         expect(response.status).toBe(403);
     });
 });
+
+describe('GET /api/orders/:order_id — orden por ID', () => {
+    it('devuelve 200 con la orden encontrada', async () => {
+        const order = await createOrderFixture();
+
+        const response = await auth(
+            request(app).get(`/api/orders/${Utils.encode(order.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('id');
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).get('/api/orders/not-a-hashid')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando la orden no existe', async () => {
+        const response = await auth(
+            request(app).get(`/api/orders/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/orders/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-orders/orders.test.js
+++ b/tests/domain/operations-orders/orders.test.js
@@ -218,3 +218,63 @@ describe('DELETE /api/orders/deleteItem/:item_id — eliminar item', () => {
         expect(response.status).toBe(403);
     });
 });
+
+describe('POST /api/orders — crear orden', () => {
+    it('devuelve 200 al crear una orden con Excel válido', async () => {
+        const { company } = await createCompanyWithYacht(`PostCo-${suffix()}`);
+        const staff = await createStaffFixture();
+        const excelBuffer = createExcelBuffer();
+
+        const response = await auth(
+            request(app)
+                .post('/api/orders')
+                .field('companyId', Utils.encode(company.id))
+                .field('userId', Utils.encode(staff.id))
+                .field('name', `Pedido-${suffix()}`)
+                .field('status', 'en espera')
+                .field('guide', `GUIDE-${suffix()}`)
+                .attach('file', excelBuffer, 'pedido.xlsx')
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource created successfully');
+    });
+
+    it('devuelve 400 sin archivo Excel', async () => {
+        const { company } = await createCompanyWithYacht(`PostCo-${suffix()}`);
+        const staff = await createStaffFixture();
+
+        const response = await auth(
+            request(app)
+                .post('/api/orders')
+                .field('companyId', Utils.encode(company.id))
+                .field('userId', Utils.encode(staff.id))
+                .field('status', 'en espera')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 con companyId hashid inválido', async () => {
+        const excelBuffer = createExcelBuffer();
+
+        const response = await auth(
+            request(app)
+                .post('/api/orders')
+                .field('companyId', 'not-a-hashid')
+                .field('userId', 'not-a-hashid')
+                .field('status', 'en espera')
+                .attach('file', excelBuffer, 'pedido.xlsx')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).post('/api/orders');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/smoke/swagger.smoke.test.js
+++ b/tests/smoke/swagger.smoke.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const swaggerJsdoc = require('swagger-jsdoc');
 const { bootTestApp, shutdownTestApp } = require('../helpers/testApp');
 
 let app;
@@ -16,5 +17,26 @@ describe('Swagger docs smoke test', () => {
         const response = await request(app).get('/api/docs/');
         expect(response.status).toBe(200);
         expect(response.text).toContain('swagger-ui');
+    });
+
+    it('documents every Orders endpoint in the OpenAPI contract', () => {
+        const spec = swaggerJsdoc({
+            definition: { openapi: '3.0.0', info: { title: 'test', version: '1.0.0' } },
+            apis: ['./src/routes/operations/orders/order.routes.js'],
+        });
+
+        expect(spec.paths).toMatchObject({
+            '/orders': {
+                get: expect.any(Object),
+                post: expect.any(Object),
+            },
+            '/orders/{order_id}': {
+                get: expect.any(Object),
+                put: expect.any(Object),
+            },
+            '/orders/deleteItem/{item_id}': {
+                delete: expect.any(Object),
+            },
+        });
     });
 });


### PR DESCRIPTION
## Resumen
- agrega cobertura de integración para los endpoints de Orders (GET, POST, PUT y DELETE)
- migra el controlador de Orders a `AppError` y `next(error)` con validación consistente de Hashids y respuestas 404
- corrige el formato de fecha del reporte general de evaluaciones a `dd/mm/yyyy`

## Pruebas
- `npx jest tests/domain/operations-orders/orders.test.js --runInBand` (18/18, tres ejecuciones consecutivas)
- `npx jest tests/domain/reports/reports.test.js --runInBand` (23/23)
- `npm test` (37 suites, 254 pruebas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)