### PR TITLE
refactor: fase-2-yachtRequest — AppError/next(error) + tests de integración

### DIFF
--- a/docs/superpowers/plans/2026-08-19-fase-2-yachtrequest-plan.md
+++ b/docs/superpowers/plans/2026-08-19-fase-2-yachtrequest-plan.md
@@ -185,10 +185,10 @@ describe('GET /api/requests — lista de solicitudes', () => {
         expect(Array.isArray(response.body)).toBe(true);
     });
 
-    it('devuelve 401 sin JWT', async () => {
+    it('devuelve 403 sin JWT', async () => {
         const response = await request(app).get('/api/requests');
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(403);
     });
 });
 ```
@@ -198,7 +198,7 @@ describe('GET /api/requests — lista de solicitudes', () => {
 ```bash
 npm test -- --testPathPattern=operations-yacht-request
 ```
-Esperado: 2/2 PASS — `getAllRequests` ya devuelve 200 y el JWT ya bloquea con 401.
+Esperado: 2/2 PASS — `getAllRequests` ya devuelve 200 y el JWT ya bloquea con 403.
 
 - [ ] **Step 4: Corregir los dos bugs de `src/services/operations/yachtRequest/yachtRequest.services.js`**
 
@@ -546,7 +546,7 @@ git commit -m "refactor: retrofit yachtRequest a AppError/next(error) + fixes de
 
 ---
 
-## Task 2: Tests de `getRequestById` (200, 400 hashid, 404, 401)
+## Task 2: Tests de `getRequestById` (200, 400 hashid, 404, 403)
 
 **Files:**
 - Modify: `tests/domain/operations-yacht-request/yachtRequest.test.js`
@@ -597,10 +597,10 @@ describe('GET /api/requests/:request_id — solicitud por ID', () => {
         expect(response.body.error.code).toBe('AppError');
     });
 
-    it('devuelve 401 sin JWT', async () => {
+    it('devuelve 403 sin JWT', async () => {
         const response = await request(app).get('/api/requests/any-id');
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(403);
     });
 });
 ```
@@ -616,12 +616,12 @@ Esperado: 6/6 PASS.
 
 ```bash
 git add tests/domain/operations-yacht-request/yachtRequest.test.js
-git commit -m "test: cubrir GET /api/requests/:request_id (200, 400, 404, 401)"
+git commit -m "test: cubrir GET /api/requests/:request_id (200, 400, 404, 403)"
 ```
 
 ---
 
-## Task 3: Tests de `createRequest` (200, 400 hashid, 401)
+## Task 3: Tests de `createRequest` (200, 400 hashid, 403)
 
 **Files:**
 - Modify: `tests/domain/operations-yacht-request/yachtRequest.test.js`
@@ -680,10 +680,10 @@ describe('POST /api/requests — crear solicitud', () => {
         expect(response.body.error.code).toBe('AppError');
     });
 
-    it('devuelve 401 sin JWT', async () => {
+    it('devuelve 403 sin JWT', async () => {
         const response = await request(app).post('/api/requests').send({});
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(403);
     });
 });
 ```
@@ -699,12 +699,12 @@ Esperado: 9/9 PASS.
 
 ```bash
 git add tests/domain/operations-yacht-request/yachtRequest.test.js
-git commit -m "test: cubrir POST /api/requests (200, 400 hashid, 401)"
+git commit -m "test: cubrir POST /api/requests (200, 400 hashid, 403)"
 ```
 
 ---
 
-## Task 4: Tests de `updateRequest` (200, 400 hashid, 404, 400 cantidad inválida, 401)
+## Task 4: Tests de `updateRequest` (200, 400 hashid, 404, 400 cantidad inválida, 403)
 
 **Files:**
 - Modify: `tests/domain/operations-yacht-request/yachtRequest.test.js`
@@ -770,12 +770,12 @@ describe('PUT /api/requests/:request_id — actualizar solicitud', () => {
         expect(response.body.error.code).toBe('AppError');
     });
 
-    it('devuelve 401 sin JWT', async () => {
+    it('devuelve 403 sin JWT', async () => {
         const response = await request(app)
             .put('/api/requests/any-id')
             .send({});
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(403);
     });
 });
 ```
@@ -791,7 +791,7 @@ Esperado: 14/14 PASS.
 
 ```bash
 git add tests/domain/operations-yacht-request/yachtRequest.test.js
-git commit -m "test: cubrir PUT /api/requests/:request_id (200, 400, 404, 400 cantidad, 401)"
+git commit -m "test: cubrir PUT /api/requests/:request_id (200, 400, 404, 400 cantidad, 403)"
 ```
 
 ---

--- a/src/controllers/operations/yachtRequest/yachtRequest.controller.js
+++ b/src/controllers/operations/yachtRequest/yachtRequest.controller.js
@@ -58,6 +58,10 @@ const createRequest = async (req, res, next) => {
         data.warehouseId = decodeId(data.warehouseId, 'warehouseId');
         data.userId = decodeId(data.userId, 'userId');
 
+        if (!Array.isArray(data.products)) {
+            throw new AppError('products debe ser un arreglo', 400);
+        }
+
         await YachtRequestService.createRequest(data)
         const warehouse = await WarehouseService.getWarehouseById(data.warehouseId)
         const staff = await Staffervice.getStaffById(data.userId)

--- a/src/controllers/operations/yachtRequest/yachtRequest.controller.js
+++ b/src/controllers/operations/yachtRequest/yachtRequest.controller.js
@@ -1,12 +1,25 @@
 const { sendEmailNewRequest, sendConfirmationEmail } = require('../../../mails/mailer');
 const Staffervice = require('../../../services/catalogs/staff.services');
 const WarehouseService = require('../../../services/operations/inventory/warehouse.services');
-const RequestService = require('../../../services/operations/yachtRequest/yachtRequest.services');
 const YachtRequestService = require('../../../services/operations/yachtRequest/yachtRequest.services');
 const Utils = require('../../../utils/Utils');
 const Quantity = require('../../../utils/quantity');
+const AppError = require('../../../errors/AppError');
 
-const getAllRequests = async (req, res) => {
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
+
+const getAllRequests = async (req, res, next) => {
     try {
         const result = await YachtRequestService.getAllRequests();
         if (result instanceof Array) {
@@ -17,57 +30,57 @@ const getAllRequests = async (req, res) => {
         }
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 
-const getRequestById = async (req, res) => {
+const getRequestById = async (req, res, next) => {
     try {
-        const requestId = Utils.decode(req.params.request_id);
-        const result = await YachtRequestService.getRequestById(requestId)
-        if (result instanceof Object) {
-            result.id = Utils.encode(result.id);
-            result.warehouseId = Utils.encode(result.warehouseId);
-            result.requestItems.map(x => (
-                x.stock = Quantity.viewCorrectQuantity(x.configuracion?.product, x.stock)
-            ))
-        }
+        const requestId = decodeId(req.params.request_id, 'request_id');
+        const result = await YachtRequestService.getRequestById(requestId);
+        if (!result) throw new AppError('Solicitud no encontrada', 404);
+
+        result.id = Utils.encode(result.id);
+        result.warehouseId = Utils.encode(result.warehouseId);
+        result.requestItems.map(x => (
+            x.stock = Quantity.viewCorrectQuantity(x.configuracion?.product, x.stock)
+        ))
 
         res.status(200).json(result);
     } catch (error) {
-        console.log(error)
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 
-const createRequest = async (req, res) => {
+const createRequest = async (req, res, next) => {
     try {
         const data = req.body;
-        data.warehouseId = Utils.decode(req.body.warehouseId);
-        data.userId = Utils.decode(req.body.userId)
+        data.warehouseId = decodeId(data.warehouseId, 'warehouseId');
+        data.userId = decodeId(data.userId, 'userId');
 
-        await RequestService.createRequest(data)
-        const company = await WarehouseService.getWarehouseById(data.warehouseId)
+        await YachtRequestService.createRequest(data)
+        const warehouse = await WarehouseService.getWarehouseById(data.warehouseId)
         const staff = await Staffervice.getStaffById(data.userId)
 
-        action = 'requerimiento'
-        sendEmailNewRequest(company.dataValues.name);
-        sendConfirmationEmail(action, company.dataValues.name, staff)
+        const action = 'requerimiento'
+        sendEmailNewRequest(warehouse.dataValues.name);
+        sendConfirmationEmail(action, warehouse.dataValues.name, staff)
         res.status(200).json({ data: 'resource created successfully' });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 
-const updateRequest = async (req, res) => {
+const updateRequest = async (req, res, next) => {
     try {
-        const requestId = Utils.decode(req.params.request_id);
+        const requestId = decodeId(req.params.request_id, 'request_id');
         const data = req.body
-        await YachtRequestService.updateRequest(data, requestId);
+        const [affectedRows] = await YachtRequestService.updateRequest(data, requestId);
+        if (affectedRows === 0) throw new AppError('Solicitud no encontrada', 404);
 
         res.status(200).json({ data: 'resource updated successfully' });
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/services/operations/yachtRequest/yachtRequest.services.js
+++ b/src/services/operations/yachtRequest/yachtRequest.services.js
@@ -7,6 +7,7 @@ const RequestItems = require('../../../models/operations/yachtRequest/requestIte
 const ProductConfiguration = require('../../../models/operations/inventory/productConfiguration');
 const Product = require('../../../models/operations/inventory/product.models');
 const Stock = require('../../../models/operations/inventory/stock.models');
+const AppError = require('../../../errors/AppError');
 
 class RequestService {
     static async getAllRequests() {
@@ -72,6 +73,8 @@ class RequestService {
                     ]
                 ]
             });
+
+            if (!result) return null;
 
             const currentPlain = result.get({ plain: true });
             if (currentPlain.group === 'drink_request') {
@@ -178,7 +181,7 @@ class RequestService {
             for (const item of data.items) {
                 const quantity = parseInt(item.quantity, 10);
                 if (isNaN(quantity) || quantity < 0) {
-                    throw new Error(`Invalid quantity for item ${item.id}`);
+                    throw new AppError(`Invalid quantity for item ${item.id}`, 400);
                 }
             }
         }

--- a/tests/domain/operations-yacht-request/yachtRequest.test.js
+++ b/tests/domain/operations-yacht-request/yachtRequest.test.js
@@ -228,6 +228,27 @@ describe('POST /api/requests — crear solicitud', () => {
         expect(response.body.error.code).toBe('AppError');
     });
 
+    it('devuelve 400 cuando products no es un arreglo', async () => {
+        const { yacht } = await createCompanyWithYacht(`PostYacht-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const staff = await createStaffFixture();
+
+        const response = await auth(
+            request(app)
+                .post('/api/requests')
+                .send({
+                    warehouseId: Utils.encode(warehouse.id),
+                    userId: Utils.encode(staff.id),
+                    name: `Requerimiento-${suffix()}`,
+                    group: 'inventory_request',
+                    status: 'Pendiente',
+                })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
     it('devuelve 403 sin JWT', async () => {
         const response = await request(app).post('/api/requests').send({});
 

--- a/tests/domain/operations-yacht-request/yachtRequest.test.js
+++ b/tests/domain/operations-yacht-request/yachtRequest.test.js
@@ -234,3 +234,66 @@ describe('POST /api/requests — crear solicitud', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// PUT /api/requests/:request_id
+// =========================================================================
+
+describe('PUT /api/requests/:request_id — actualizar solicitud', () => {
+    it('devuelve 200 al actualizar la solicitud', async () => {
+        const req = await createRequestFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/requests/${Utils.encode(req.id)}`)
+                .send({ status: 'Procesado' })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource updated successfully');
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).put('/api/requests/not-a-hashid').send({ status: 'Procesado' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando la solicitud no existe', async () => {
+        const response = await auth(
+            request(app)
+                .put(`/api/requests/${Utils.encode(999999)}`)
+                .send({ status: 'Procesado' })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando un item tiene cantidad inválida', async () => {
+        const req = await createRequestFixture();
+        const product = await createProductFixture();
+        const config = await createProductConfigFixture(product.id);
+        const item = await createRequestItemFixture(req.id, config.id);
+
+        const response = await auth(
+            request(app)
+                .put(`/api/requests/${Utils.encode(req.id)}`)
+                .send({ items: [{ id: item.id, quantity: -1 }] })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app)
+            .put('/api/requests/any-id')
+            .send({});
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-yacht-request/yachtRequest.test.js
+++ b/tests/domain/operations-yacht-request/yachtRequest.test.js
@@ -1,0 +1,137 @@
+// El mock debe ir antes de cualquier require que importe mailer
+jest.mock('../../../src/mails/mailer', () => ({
+    sendEmailNewRequest: jest.fn(),
+    sendConfirmationEmail: jest.fn(),
+}));
+
+const request = require('supertest');
+const { bootTestApp, shutdownTestApp } = require('../../helpers/testApp');
+const { createAuthenticatedUser } = require('../../helpers/auth');
+const { createDepartment, createPosition, createCompanyWithYacht } = require('../../helpers/staffFixtures');
+const Staff = require('../../../src/models/catalogs/staff.models');
+const Warehouse = require('../../../src/models/catalogs/wareHouse.models');
+const Request = require('../../../src/models/operations/yachtRequest/request.models');
+const RequestItems = require('../../../src/models/operations/yachtRequest/requestItems.models');
+const Product = require('../../../src/models/operations/inventory/product.models');
+const ProductConfiguration = require('../../../src/models/operations/inventory/productConfiguration');
+const Utils = require('../../../src/utils/Utils');
+
+let app;
+let token;
+let fixtureCounter = 0;
+
+const auth = (httpRequest) => httpRequest.set('Authorization', `Bearer ${token}`);
+const suffix = () => {
+    fixtureCounter += 1;
+    return `${Date.now()}-${fixtureCounter}`;
+};
+
+beforeAll(async () => {
+    app = await bootTestApp();
+    token = await createAuthenticatedUser(app);
+}, 60000);
+
+afterAll(async () => {
+    await shutdownTestApp();
+});
+
+// --- Helpers de fixtures --------------------------------------------------
+
+async function createStaffFixture() {
+    const dept = await createDepartment(`Dept-${suffix()}`);
+    const pos = await createPosition(`Pos-${suffix()}`);
+    const s = suffix();
+    return Staff.create({
+        firstName: 'TEST',
+        lastName: `Request${s}`,
+        email: `request-test-${s}@example.com`,
+        cellPhone: '0966666666',
+        password: 'Sup3rSecret!',
+        departamentId: dept.id,
+        positionId: pos.id,
+        contractType: 'Fijo',
+        active: true,
+    });
+}
+
+async function createWarehouseFixture(yachtId, overrides = {}) {
+    return Warehouse.create({
+        name: `Warehouse-${suffix()}`,
+        location: 'Bodega Test',
+        type: 'Yate',
+        yachtId,
+        ...overrides,
+    });
+}
+
+async function createRequestFixture(overrides = {}) {
+    const { yacht } = await createCompanyWithYacht(`Request Company ${suffix()}`);
+    const warehouse = await createWarehouseFixture(yacht.id);
+    const staff = await createStaffFixture();
+    return Request.create({
+        warehouseId: warehouse.id,
+        userId: staff.id,
+        name: `Requerimiento-${suffix()}`,
+        group: 'inventory_request',
+        status: 'Pendiente',
+        ...overrides,
+    });
+}
+
+async function createProductFixture(overrides = {}) {
+    const s = suffix();
+    return Product.create({
+        name: `Producto-${s}`,
+        sku: `SKU-${s}`,
+        type: 'DISCRETE',
+        active: true,
+        ...overrides,
+    });
+}
+
+async function createProductConfigFixture(productId, overrides = {}) {
+    return ProductConfiguration.create({
+        name: `Config-${suffix()}`,
+        group: 'default',
+        productId,
+        sixteenPax: '1',
+        eighteenPax: '1',
+        twentyPax: '1',
+        twentyTwoPax: '1',
+        twentyFourPax: '1',
+        active: true,
+        ...overrides,
+    });
+}
+
+async function createRequestItemFixture(requestId, configurationId, overrides = {}) {
+    return RequestItems.create({
+        requestId,
+        configurationId,
+        stock: 10,
+        order: 0,
+        quantity: 5,
+        ...overrides,
+    });
+}
+
+// =========================================================================
+// GET /api/requests
+// =========================================================================
+
+describe('GET /api/requests — lista de solicitudes', () => {
+    it('devuelve 200 con la lista de solicitudes', async () => {
+        await createRequestFixture();
+
+        const response = await auth(request(app).get('/api/requests'));
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/requests');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-yacht-request/yachtRequest.test.js
+++ b/tests/domain/operations-yacht-request/yachtRequest.test.js
@@ -180,3 +180,57 @@ describe('GET /api/requests/:request_id — solicitud por ID', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// POST /api/requests — crear solicitud
+// =========================================================================
+
+describe('POST /api/requests — crear solicitud', () => {
+    it('devuelve 200 al crear una solicitud', async () => {
+        const { yacht } = await createCompanyWithYacht(`PostYacht-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const staff = await createStaffFixture();
+        const product = await createProductFixture();
+        const config = await createProductConfigFixture(product.id);
+
+        const response = await auth(
+            request(app)
+                .post('/api/requests')
+                .send({
+                    warehouseId: Utils.encode(warehouse.id),
+                    userId: Utils.encode(staff.id),
+                    name: `Requerimiento-${suffix()}`,
+                    group: 'inventory_request',
+                    status: 'Pendiente',
+                    products: [
+                        { configurationId: config.id, stock: 5, order: 0, quantity: 3 },
+                    ],
+                })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource created successfully');
+    });
+
+    it('devuelve 400 con warehouseId hashid inválido', async () => {
+        const response = await auth(
+            request(app)
+                .post('/api/requests')
+                .send({
+                    warehouseId: 'not-a-hashid',
+                    userId: 'not-a-hashid',
+                    status: 'Pendiente',
+                    products: [],
+                })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).post('/api/requests').send({});
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-yacht-request/yachtRequest.test.js
+++ b/tests/domain/operations-yacht-request/yachtRequest.test.js
@@ -135,3 +135,48 @@ describe('GET /api/requests — lista de solicitudes', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// GET /api/requests/:request_id
+// =========================================================================
+
+describe('GET /api/requests/:request_id — solicitud por ID', () => {
+    it('devuelve 200 con la solicitud encontrada', async () => {
+        const req = await createRequestFixture();
+        const product = await createProductFixture();
+        const config = await createProductConfigFixture(product.id);
+        await createRequestItemFixture(req.id, config.id);
+
+        const response = await auth(
+            request(app).get(`/api/requests/${Utils.encode(req.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('id');
+        expect(response.body.requestItems).toHaveLength(1);
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).get('/api/requests/not-a-hashid')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando la solicitud no existe', async () => {
+        const response = await auth(
+            request(app).get(`/api/requests/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/requests/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});


### PR DESCRIPTION
## Resumen

Retrofitea los cuatro endpoints del dominio `yachtRequest` (`/api/requests`) al patrón `AppError`/`next(error)` (mismo estándar ya aplicado en `orders`, `auth`, `downloads`, etc.), corrige 3 bugs reales, y cubre el dominio con 15 tests de integración.

**Cambios en el controller (`src/controllers/operations/yachtRequest/yachtRequest.controller.js`):**
- Añade helper local `decodeId` (hashid inválido → `AppError(400)`)
- Elimina el import duplicado `RequestService`/`YachtRequestService` (mismo módulo, dos nombres)
- `getAllRequests`, `getRequestById`, `createRequest`, `updateRequest`: reemplazan `res.status(400).json(error.message)` por `next(error)`
- `getRequestById`: 404 explícito cuando la solicitud no existe, quita `console.log` de depuración
- `createRequest`: declara `const action` (fix de variable global sin declarar), renombra `company` → `warehouse`, valida que `products` sea un arreglo (400 en vez de 500)
- `updateRequest`: 404 vía `affectedRows === 0` (mismo patrón que `orders.controller.js`)

**Cambios en el servicio (`src/services/operations/yachtRequest/yachtRequest.services.js`):**
- `getRequestById`: retorna `null` en vez de crashear con `TypeError` cuando la solicitud no existe (antes reportaba 400 con un mensaje interno de Node en vez de un 404 limpio)
- `updateRequest`: la validación de cantidad de items lanza `AppError(400)` en vez de `Error` genérico (antes se reportaba como 500)
- `createDrinkRequest` queda intacto (fuera de scope, lo usa `bar/cruise.controller.js`)

**Tests:** 15 tests de integración en `tests/domain/operations-yacht-request/yachtRequest.test.js` — suite completa (270/270) en verde.

## Proceso

Implementado con `superpowers:subagent-driven-development` — plan en `docs/superpowers/plans/2026-08-19-fase-2-yachtrequest-plan.md`, un subagente implementador + revisor por task, y una revisión final de rama completa (modelo más capaz) antes de este PR.

**Decisiones registradas durante la implementación:**
- El plan original especificaba `401` para "sin JWT" en los tests; se corrigió a `403` (comportamiento real de `authJwt.verifyToken`, confirmado contra el middleware y contra los tests ya mergeados de `orders`/`downloads`).
- La revisión final encontró que `updateRequest`'s `affectedRows === 0 → 404` puede dar un falso 404 si una solicitud existente no cambia ningún campo dentro del mismo segundo (granularidad de `updatedAt` en MySQL). Es el mismo patrón ya presente en el `orders` ya mergeado — se dejó igual (no se diverge de la convención establecida) y se deja como posible seguimiento cross-dominio.
- Se corrigió un segundo hallazgo de la revisión final (`POST /api/requests` con `products` faltante o no-arreglo devolvía 500 en vez de 400) en este mismo branch, con su test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
