### PR TITLE
refactor: fase-2-inventory/products — AppError/next(error) + tests de integración

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -90,7 +90,8 @@ Dominios de operaciones ya retrofiteados: `comentCard`. Dominio RRHH completo:
 endpoints; `GET /reports/request/:request_id` se eliminó por dead code
 irreparable, confirmado por el usuario). Dominio `downloads` retrofiteado (7
 endpoints); se restauró `FormatService.getRequestById`, eliminado erróneamente
-como dead code mientras `downloadSolicitud` todavía lo consumía.
+como dead code mientras `downloadSolicitud` todavía lo consumía. Dominio
+`inventory/products` retrofiteado (10 endpoints).
 
 ## Validación de identificadores codificados
 

--- a/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
+++ b/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
@@ -1,0 +1,1436 @@
+# Fase 2 — Dominio Inventory/Products — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retrofit the `inventory/products` domain (`/api/products`, 10 endpoints) to the `AppError`/`next(error)` error-handling standard, fix the four verified 200-instead-of-404 bugs, fix the PK-encoding no-op in `getProduct`, and cover the domain with real-DB tests.
+
+**Architecture:** No new files besides the test suite. `src/controllers/operations/inventory/products.controller.js` and `src/services/operations/inventory/products.services.js` are modified in place, endpoint by endpoint. Each task retrofits one or two related handlers and adds the tests that pin down their new behavior. `src/routes/operations/inventory/products.routes.js` needs no changes — Express already passes `next` to every route handler regardless of whether the handler declares it.
+
+**Tech Stack:** Express, Sequelize (MySQL), Jest + Supertest (real DB, no mocks), existing `AppError`/`errorHandler` middleware, `hashids` via `src/utils/Utils.js`.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md`
+
+## Global Constraints
+
+- All 10 handlers end up with signature `(req, res, next)` and every `catch` block calls `next(error)` — no handler keeps `res.status(400).json(error.message)`.
+- Hashid params (`product_id`, `warehouse_id`, `stock_id`, `data.userId`) are decoded through a local `decodeId(value, fieldName)` helper that throws `AppError('${fieldName} inválido', 400)` on failure. `configuration_id` is **not** hashid-encoded — do not decode it (confirmed out of scope in the spec).
+- "Not found" on `updateProduct` and `switchConfirguration` is detected by fetching the row first (`findByPk`) and throwing `AppError(msg, 404)` if absent — **never** by checking `affectedRows === 0` (verified empirically: MySQL without `CLIENT_FOUND_ROWS` reports `affectedRows: 0` both for a missing row and for an idempotent no-op update; using it would produce false 404s).
+- Every new/changed error path that a client can trigger gets a test asserting the exact status code and, where applicable, `response.body.error.code === 'AppError'`.
+- Run `npx jest tests/domain/operations-inventory-products --runInBand` after every task; it must stay green from Task 1 onward (each task only adds tests for behavior that task itself implements).
+
+---
+
+### Task 1: Test scaffold, fixtures, `decodeId` helper, `getProducts` + `getProduct`
+
+**Files:**
+- Create: `tests/domain/operations-inventory-products/products.test.js`
+- Modify: `src/controllers/operations/inventory/products.controller.js:1-3` (imports), `:20-32` (`getProducts`), `:72-83` (`getProduct`)
+
+**Interfaces:**
+- Produces: `decodeId(value, fieldName)` in the controller module scope — used by every later task that touches `product_id`, `warehouse_id`, `stock_id`, or `data.userId`.
+- Produces fixture helpers in the test file, reused by every later task: `createStaffFixture()`, `createWarehouseFixture(yachtId, overrides)`, `createProductFixture(overrides)`, `createProductConfigFixture(productId, overrides)`, `createStockFixture(productId, warehouseId, companyId, overrides)`, plus `auth(httpRequest)` and `suffix()`.
+
+- [ ] **Step 1: Write the test file with fixtures and the first two describe blocks**
+
+```js
+const request = require('supertest');
+const { bootTestApp, shutdownTestApp } = require('../../helpers/testApp');
+const { createAuthenticatedUser } = require('../../helpers/auth');
+const { createDepartment, createPosition, createCompanyWithYacht } = require('../../helpers/staffFixtures');
+const Staff = require('../../../src/models/catalogs/staff.models');
+const Warehouse = require('../../../src/models/catalogs/wareHouse.models');
+const Product = require('../../../src/models/operations/inventory/product.models');
+const ProductConfiguration = require('../../../src/models/operations/inventory/productConfiguration');
+const Stock = require('../../../src/models/operations/inventory/stock.models');
+const Transaction = require('../../../src/models/operations/inventory/transaction.models');
+const Utils = require('../../../src/utils/Utils');
+
+let app;
+let token;
+let fixtureCounter = 0;
+
+const auth = (httpRequest) => httpRequest.set('Authorization', `Bearer ${token}`);
+const suffix = () => {
+    fixtureCounter += 1;
+    return `${Date.now()}-${fixtureCounter}`;
+};
+
+beforeAll(async () => {
+    app = await bootTestApp();
+    token = await createAuthenticatedUser(app);
+}, 60000);
+
+afterAll(async () => {
+    await shutdownTestApp();
+});
+
+// --- Helpers de fixtures --------------------------------------------------
+
+async function createStaffFixture() {
+    const dept = await createDepartment(`Dept-${suffix()}`);
+    const pos = await createPosition(`Pos-${suffix()}`);
+    const s = suffix();
+    return Staff.create({
+        firstName: 'TEST',
+        lastName: `Product${s}`,
+        email: `product-test-${s}@example.com`,
+        cellPhone: '0966666666',
+        password: 'Sup3rSecret!',
+        departamentId: dept.id,
+        positionId: pos.id,
+        contractType: 'Fijo',
+        active: true,
+    });
+}
+
+async function createWarehouseFixture(yachtId, overrides = {}) {
+    return Warehouse.create({
+        name: `Warehouse-${suffix()}`,
+        location: 'Bodega Test',
+        type: 'Yate',
+        yachtId,
+        ...overrides,
+    });
+}
+
+async function createProductFixture(overrides = {}) {
+    const s = suffix();
+    return Product.create({
+        name: `Producto-${s}`,
+        sku: `SKU-${s}`,
+        type: 'DISCRETE',
+        unit: 'unidad',
+        active: true,
+        ...overrides,
+    });
+}
+
+async function createProductConfigFixture(productId, overrides = {}) {
+    return ProductConfiguration.create({
+        name: `Config-${suffix()}`,
+        group: 'default',
+        productId,
+        sixteenPax: '1',
+        eighteenPax: '1',
+        twentyPax: '1',
+        twentyTwoPax: '1',
+        twentyFourPax: '1',
+        active: true,
+        ...overrides,
+    });
+}
+
+async function createStockFixture(productId, warehouseId, companyId, overrides = {}) {
+    return Stock.create({
+        productId,
+        warehouseId,
+        companyId,
+        quantity: 10,
+        max: 20,
+        min: 2,
+        ...overrides,
+    });
+}
+
+// =========================================================================
+// GET /api/products
+// =========================================================================
+
+describe('GET /api/products — lista de productos', () => {
+    it('devuelve 200 con la lista de productos', async () => {
+        await createProductFixture();
+
+        const response = await auth(request(app).get('/api/products'));
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products');
+
+        expect(response.status).toBe(403);
+    });
+});
+
+// =========================================================================
+// GET /api/products/:product_id
+// =========================================================================
+
+describe('GET /api/products/:product_id — producto por ID', () => {
+    it('devuelve 200 con el id codificado como hashid', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(product.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBe(Utils.encode(product.id));
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).get('/api/products/not-a-hashid')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el producto no existe', async () => {
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run the suite and confirm it fails on the new tests**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: FAIL — `GET /api/products/:product_id` tests fail because the current
+handler returns 200 with the raw numeric id (PK-encoding bug), returns 200
+with `null` for a missing id instead of 404, and the hashid-decode error is
+unhandled (no `AppError`/`next` wiring yet, so it 400s via the old catch but
+`response.body.error` doesn't exist — assert on that shape failing is
+expected here).
+
+- [ ] **Step 3: Add the `decodeId` helper and retrofit `getProducts` / `getProduct`**
+
+Modify `src/controllers/operations/inventory/products.controller.js:1-3`:
+
+```js
+const ProductService = require('../../../services/operations/inventory/products.services');
+const Utils = require('../../../utils/Utils');
+const Quantity = require('../../../utils/quantity');
+const AppError = require('../../../errors/AppError');
+
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
+```
+
+Modify `getProducts` (originally lines 20-32):
+
+```js
+const getProducts = async (req, res, next) => {
+    try {
+        const result = await ProductService.getAll();
+        if (result instanceof Array) {
+            result.map((x) => {
+                x.dataValues.id = Utils.encode(x.dataValues.id);
+            });
+        }
+        res.status(200).json(result);
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+Modify `getProduct` (originally lines 72-83) — fixes the PK-encoding no-op
+(`.dataValues.id`, not `.id`) and the missing 404:
+
+```js
+const getProduct = async (req, res, next) => {
+    try {
+        const productId = decodeId(req.params.product_id, 'product_id');
+        const result = await ProductService.getProductById(productId);
+        if (!result) throw new AppError('Producto no encontrado', 404);
+        result.dataValues.id = Utils.encode(result.dataValues.id);
+        res.status(200).json(result);
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 4: Run the suite and confirm the new tests pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js
+git commit -m "test+fix: retrofit getProducts/getProduct a AppError, corregir PK-encoding y 404 de getProduct"
+```
+
+---
+
+### Task 2: `findProduct` — 404 en vez de 400
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:5-18`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: nothing new from Task 1 (uses `AppError`, already imported).
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to the test file:
+
+```js
+// =========================================================================
+// GET /api/products/findProduct/:sku
+// =========================================================================
+
+describe('GET /api/products/findProduct/:sku — buscar por SKU', () => {
+    it('devuelve 200 con el producto encontrado', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app).get(`/api/products/findProduct/${product.sku}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.sku).toBe(product.sku);
+    });
+
+    it('devuelve 404 cuando el sku no existe', async () => {
+        const response = await auth(
+            request(app).get(`/api/products/findProduct/NOPE-${suffix()}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/findProduct/any-sku');
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm the 404 test fails**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "buscar por SKU"`
+Expected: FAIL on "devuelve 404 cuando el sku no existe" — current handler returns 400.
+
+- [ ] **Step 3: Retrofit `findProduct`**
+
+Modify `src/controllers/operations/inventory/products.controller.js:5-18`:
+
+```js
+const findProduct = async (req, res, next) => {
+    try {
+        const sku = req.params.sku.replace(/^0+/, '');
+        const result = await ProductService.findProduct(sku);
+        if (!result) throw new AppError(`Producto no encontrado para sku: ${sku}`, 404);
+        res.status(200).json({ data: result });
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 4: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js
+git commit -m "test+fix: findProduct responde 404 en vez de 400 cuando el sku no existe"
+```
+
+---
+
+### Task 3: `getProductsWithConfigurations` — retrofit sin cambio de comportamiento
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:34-48`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `createProductFixture`, `createProductConfigFixture` from Task 1.
+
+- [ ] **Step 1: Add the failing test**
+
+```js
+// =========================================================================
+// GET /api/products/allProductsWithConfigurations
+// =========================================================================
+
+describe('GET /api/products/allProductsWithConfigurations', () => {
+    it('devuelve 200 con las configuraciones activas', async () => {
+        const product = await createProductFixture();
+        await createProductConfigFixture(product.id);
+
+        const response = await auth(
+            request(app).get('/api/products/allProductsWithConfigurations')
+        );
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/allProductsWithConfigurations');
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm the 403 test passes but nothing regresses**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "allProductsWithConfigurations"`
+Expected: PASS already (this endpoint's happy path doesn't change) — this
+step is a sanity check, not a red step; skip to Step 3 directly if both
+pass.
+
+- [ ] **Step 3: Retrofit to `next(error)`**
+
+Modify `src/controllers/operations/inventory/products.controller.js:34-48`:
+
+```js
+const getProductsWithConfigurations = async (req, res, next) => {
+    try {
+        const result = await ProductService.getProductsWithConfigurations();
+        if (result instanceof Array) {
+            result.map((x) => {
+                x.product.wineries.map(warehose => {
+                    warehose.dataValues.warehouseId = Utils.encode(warehose.dataValues.warehouseId);
+                })
+            });
+        }
+        res.status(200).json(result);
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 4: Run the full domain suite**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js
+git commit -m "test+fix: retrofit getProductsWithConfigurations a next(error)"
+```
+
+---
+
+### Task 4: `createProduct` — sku requerido + AppError en SKU duplicado
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:85-97`
+- Modify: `src/services/operations/inventory/products.services.js:1-10` (imports), `:151-181` (`createProduct`)
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `AppError` (controller already imports it from Task 1; service needs its own import).
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+// =========================================================================
+// POST /api/products/createProduct
+// =========================================================================
+
+describe('POST /api/products/createProduct — crear producto', () => {
+    it('devuelve 200 al crear un producto', async () => {
+        const s = suffix();
+        const response = await auth(
+            request(app)
+                .post('/api/products/createProduct')
+                .send({ name: `Nuevo-${s}`, sku: `NEW-${s}`, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource created successfully');
+    });
+
+    it('devuelve 400 cuando falta sku', async () => {
+        const response = await auth(
+            request(app)
+                .post('/api/products/createProduct')
+                .send({ name: `SinSku-${suffix()}`, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando el sku ya existe', async () => {
+        const existing = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .post('/api/products/createProduct')
+                .send({ name: `Dup-${suffix()}`, sku: existing.sku, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).post('/api/products/createProduct').send({});
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm the sku-related tests fail**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "crear producto"`
+Expected: FAIL on "falta sku" (currently throws an uncaught `TypeError` from
+`.replace()` on `undefined`, still surfaces as 400 via the old catch-all but
+without `response.body.error.code`) and on "sku ya existe" (currently a
+generic `Error`, same issue).
+
+- [ ] **Step 3: Add `AppError` import and duplicate-sku fix in the service**
+
+Modify `src/services/operations/inventory/products.services.js:1-10`:
+
+```js
+const Product = require('../../../models/operations/inventory/product.models');
+const LaundryYacht = require('../../../models/operations/yachtRequest/laundryYacht');
+const db = require('../../../utils/database');
+const ProductConfiguration = require('../../../models/operations/inventory/productConfiguration');
+const Stock = require('../../../models/operations/inventory/stock.models');
+const Company = require('../../../models/catalogs/company.models');
+const { Sequelize, Op } = require('sequelize');
+const StockHistory = require('../../../models/operations/inventory/stockHistory.models');
+const Transaction = require('../../../models/operations/inventory/transaction.models');
+const Quantity = require('../../../utils/quantity');
+const AppError = require('../../../errors/AppError');
+```
+
+Modify `createProduct` (originally lines 151-181), only the duplicate-sku
+branch changes:
+
+```js
+    static async createProduct(data) {
+        const transaction = await db.transaction();
+        try {
+
+            const product = await Product.findOne({
+                where: { sku: data.sku },
+                transaction
+            });
+
+            if (product) {
+                throw new AppError(`El producto con el SKU: ${product.sku} ya existe`, 400);
+            }
+
+            const result = await Product.create(data, { transaction });
+
+            if (Array.isArray(data.configurations) && data.configurations.length > 0) {
+                const configurations = data.configurations.map(config => ({
+                    ...config,
+                    productId: result.id,
+                }));
+
+                await ProductConfiguration.bulkCreate(configurations, { transaction });
+            }
+
+            await transaction.commit();
+            return result;
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    }
+```
+
+- [ ] **Step 4: Add the sku-required guard and `next(error)` wiring in the controller**
+
+Modify `src/controllers/operations/inventory/products.controller.js:85-97`:
+
+```js
+const createProduct = async (req, res, next) => {
+    try {
+        const product = req.body;
+        if (!product.sku) {
+            throw new AppError('sku es requerido', 400);
+        }
+        product.sku = product.sku.replace(/^0+/, '');
+        const result = await ProductService.createProduct(product);
+        if (result) {
+            res.status(200).json({ data: 'resource created successfully' });
+        }
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 5: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (15 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js src/services/operations/inventory/products.services.js
+git commit -m "test+fix: createProduct exige sku y clasifica SKU duplicado como AppError 400"
+```
+
+---
+
+### Task 5: `updateProduct` — sku requerido + decodeId + 404 "buscar primero"
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:99-109`
+- Modify: `src/services/operations/inventory/products.services.js:184-252`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `decodeId` (controller, Task 1), `AppError` (service, Task 4).
+- Produces: `ProductService.updateProduct` now throws `AppError('Producto no encontrado', 404)` when `id` doesn't exist — no other caller depends on its previous silent-success behavior (only this controller calls it).
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+// =========================================================================
+// PUT /api/products/updateProduct/:product_id
+// =========================================================================
+
+describe('PUT /api/products/updateProduct/:product_id — actualizar producto', () => {
+    it('devuelve 200 al actualizar el producto', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(product.id)}`)
+                .send({ name: 'Actualizado', sku: product.sku, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource updated successfully');
+    });
+
+    it('devuelve 200 al reenviar los mismos valores (update idempotente)', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(product.id)}`)
+                .send({ name: product.name, sku: product.sku, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(200);
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app)
+                .put('/api/products/updateProduct/not-a-hashid')
+                .send({ name: 'X', sku: 'X', type: 'DISCRETE' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta sku', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(product.id)}`)
+                .send({ name: 'X', type: 'DISCRETE' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el producto no existe', async () => {
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(999999)}`)
+                .send({ name: 'X', sku: `X-${suffix()}`, type: 'DISCRETE' })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).put('/api/products/updateProduct/any-id').send({});
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+The idempotent-update test is the regression guard for the `affectedRows`
+pitfall documented in the spec: it must return 200, not 404.
+
+- [ ] **Step 2: Run and confirm the new failure modes**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "actualizar producto"`
+Expected: FAIL on "hashid inválido" (500/undefined behavior today), "falta
+sku" (uncaught `TypeError`), and "no existe" (currently 200, not 404).
+
+- [ ] **Step 3: Add the "buscar primero" existence check in the service**
+
+Modify `src/services/operations/inventory/products.services.js:184-252`,
+only the opening lines change:
+
+```js
+    static async updateProduct(product, id) {
+        const transaction = await db.transaction();
+
+        try {
+            const existing = await Product.findByPk(id, { transaction });
+            if (!existing) {
+                throw new AppError('Producto no encontrado', 404);
+            }
+
+            const result = await Product.update(
+                {
+                    name: product.name,
+                    sku: product.sku,
+                    type: product.type,
+                    unit: product.unit,
+                    presentationQuantity: product.presentationQuantity
+                },
+                {
+                    where: { id },
+                    transaction
+                }
+            );
+
+            if (Array.isArray(product.configurations)) {
+
+                const incomingConfigs = product.configurations;
+                const incomingIds = incomingConfigs
+                    .filter(cfg => cfg.id)
+                    .map(cfg => cfg.id);
+
+                await ProductConfiguration.destroy({
+                    where: {
+                        productId: id,
+                        ...(incomingIds.length && { id: { [Op.notIn]: incomingIds } })
+                    },
+                    transaction
+                });
+
+                for (const config of incomingConfigs) {
+                    if (config.id) {
+                        await ProductConfiguration.update(
+                            {
+                                name: config.name,
+                                group: config.group,
+                                sixteenPax: config.sixteenPax,
+                                eighteenPax: config.eighteenPax,
+                                twentyPax: config.twentyPax,
+                                twentyTwoPax: config.twentyTwoPax,
+                                twentyFourPax: config.twentyFourPax,
+                            },
+                            {
+                                where: { id: config.id },
+                                transaction
+                            }
+                        );
+                    } else {
+                        await ProductConfiguration.create(
+                            {
+                                ...config,
+                                productId: id
+                            },
+                            { transaction }
+                        );
+                    }
+                }
+            }
+
+            await transaction.commit();
+            return result
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    }
+```
+
+- [ ] **Step 4: Add sku-required guard, `decodeId`, and `next(error)` in the controller**
+
+Modify `src/controllers/operations/inventory/products.controller.js:99-109`:
+
+```js
+const updateProduct = async (req, res, next) => {
+    try {
+        const productId = decodeId(req.params.product_id, 'product_id');
+        const product = req.body;
+        if (!product.sku) {
+            throw new AppError('sku es requerido', 400);
+        }
+        product.sku = product.sku.replace(/^0+/, '');
+        await ProductService.updateProduct(product, productId);
+        res.status(200).json({ data: 'resource updated successfully' });
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 5: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (21 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js src/services/operations/inventory/products.services.js
+git commit -m "test+fix: updateProduct valida sku/hashid y responde 404 real via buscar-primero (no affectedRows)"
+```
+
+---
+
+### Task 6: `deleteProduct` — decodeId + 404
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:111-120`
+- Modify: `src/services/operations/inventory/products.services.js:255-266`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `decodeId` (controller, Task 1), `AppError` (service, Task 4).
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+// =========================================================================
+// DELETE /api/products/:product_id
+// =========================================================================
+
+describe('DELETE /api/products/:product_id — eliminar producto', () => {
+    it('devuelve 200 al eliminar el producto', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app).delete(`/api/products/${Utils.encode(product.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource deleted successfully');
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(request(app).delete('/api/products/not-a-hashid'));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el producto no existe', async () => {
+        const response = await auth(
+            request(app).delete(`/api/products/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).delete('/api/products/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm "no existe" fails**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "eliminar producto"`
+Expected: FAIL on "no existe" (today: 200 with `data: undefined`) and on
+"hashid inválido" (`response.body.error` doesn't exist today).
+
+- [ ] **Step 3: Retrofit the service's `delete`**
+
+Modify `src/services/operations/inventory/products.services.js:255-266`:
+
+```js
+    static async delete(productId) {
+        try {
+            const result = await Product.destroy({
+                where: { id: productId }
+            });
+            if (!result) {
+                throw new AppError('Producto no encontrado', 404);
+            }
+            return 'resource deleted successfully'
+        } catch (error) {
+            throw error;
+        }
+    }
+```
+
+- [ ] **Step 4: Retrofit the controller**
+
+Modify `src/controllers/operations/inventory/products.controller.js:111-120`:
+
+```js
+const deleteProduct = async (req, res, next) => {
+    try {
+        const productId = decodeId(req.params.product_id, 'product_id');
+        const result = await ProductService.delete(productId);
+        res.status(200).json({ data: result })
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 5: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (25 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js src/services/operations/inventory/products.services.js
+git commit -m "test+fix: deleteProduct valida hashid y responde 404 cuando el producto no existe"
+```
+
+---
+
+### Task 7: `switchConfirguration` — 404 "buscar primero"
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:123-137`
+- Modify: `src/services/operations/inventory/products.services.js:268-275`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `AppError` (service, Task 4).
+- Produces: `ProductService.switchConfirguration(data, configurationId)` — signature change from `(data, options)` to `(data, configurationId)`; the only caller is this controller, updated in the same task.
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+// =========================================================================
+// PUT /api/products/configurations/switchConfiguration/:configuration_id
+// =========================================================================
+
+describe('PUT /api/products/configurations/switchConfiguration/:configuration_id', () => {
+    it('devuelve 200 al actualizar la configuración', async () => {
+        const product = await createProductFixture();
+        const config = await createProductConfigFixture(product.id);
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/configurations/switchConfiguration/${config.id}`)
+                .send({ active: false })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource updated successfully');
+    });
+
+    it('devuelve 404 cuando la configuración no existe', async () => {
+        const response = await auth(
+            request(app)
+                .put('/api/products/configurations/switchConfiguration/999999')
+                .send({ active: false })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app)
+            .put('/api/products/configurations/switchConfiguration/1')
+            .send({});
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm "no existe" fails**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "switchConfiguration"`
+Expected: FAIL on "no existe" — today it returns 200 (the `[0]`
+affected-rows array is truthy).
+
+- [ ] **Step 3: Retrofit the service**
+
+Modify `src/services/operations/inventory/products.services.js:268-275`:
+
+```js
+    static async switchConfirguration(data, configurationId) {
+        try {
+            const existing = await ProductConfiguration.findByPk(configurationId);
+            if (!existing) {
+                throw new AppError('Configuración no encontrada', 404);
+            }
+            await ProductConfiguration.update(data, { where: { id: configurationId } });
+            return true;
+        } catch (error) {
+            throw error;
+        }
+    }
+```
+
+- [ ] **Step 4: Retrofit the controller**
+
+Modify `src/controllers/operations/inventory/products.controller.js:123-137`:
+
+```js
+const switchConfirguration = async (req, res, next) => {
+    try {
+        const configurationId = req.params.configuration_id;
+        const data = req.body
+        await ProductService.switchConfirguration(data, configurationId);
+        res.status(200).json({ data: 'resource updated successfully' });
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 5: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (28 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js src/services/operations/inventory/products.services.js
+git commit -m "test+fix: switchConfirguration responde 404 real via buscar-primero (no affectedRows)"
+```
+
+---
+
+### Task 8: `getProductsByWarehouse` — decodeId
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:50-70`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `decodeId` (Task 1), `createCompanyWithYacht` (`tests/helpers/staffFixtures.js`, already imported in Task 1), `createWarehouseFixture`, `createProductFixture`, `createStockFixture` (Task 1).
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+// =========================================================================
+// GET /api/products/:warehouse_id/stocks
+// =========================================================================
+
+describe('GET /api/products/:warehouse_id/stocks — stock por warehouse', () => {
+    it('devuelve 200 con el stock del warehouse', async () => {
+        const { company, yacht } = await createCompanyWithYacht(`StockCo-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const product = await createProductFixture();
+        await createStockFixture(product.id, warehouse.id, company.id);
+
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(warehouse.id)}/stocks`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].product.sku).toBe(product.sku);
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).get('/api/products/not-a-hashid/stocks')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/any-id/stocks');
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm "hashid inválido" fails**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "stock por warehouse"`
+Expected: FAIL on "hashid inválido" — today `Utils.decode` returns
+`undefined`, which is interpolated into the raw `Sequelize.literal` SQL and
+either produces a SQL error (500-ish) or silently misbehaves, not a clean
+`AppError` 400.
+
+- [ ] **Step 3: Retrofit the controller**
+
+Modify `src/controllers/operations/inventory/products.controller.js:50-70`:
+
+```js
+const getProductsByWarehouse = async (req, res, next) => {
+    try {
+        const warehouseId = decodeId(req.params.warehouse_id, 'warehouse_id');
+        const result = await ProductService.getProductsByWarehouse(warehouseId);
+
+        if (result instanceof Array) {
+            result.map((x) => {
+                x.id = Utils.encode(x.id);
+                x.companyId = Utils.encode(x.companyId);
+                x.productId = Utils.encode(x.productId);
+                x.quantity = Quantity.viewCorrectQuantity(x.product, x.quantity)
+                x.totalBarConsumption = Quantity.viewCorrectQuantity(x.product, x.totalBarConsumption)
+
+            });
+        }
+        res.status(200).json(result);
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 4: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (31 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js
+git commit -m "test+fix: getProductsByWarehouse valida el hashid antes de usarlo en SQL crudo"
+```
+
+---
+
+### Task 9: `updateStock` — decodeId, validación explícita, 404 con AppError
+
+**Files:**
+- Modify: `src/controllers/operations/inventory/products.controller.js:139-150`
+- Modify: `src/services/operations/inventory/products.services.js:277-358`
+- Test: `tests/domain/operations-inventory-products/products.test.js`
+
+**Interfaces:**
+- Consumes: `decodeId` (Task 1), `AppError` (service, Task 4), `createStaffFixture`, `createCompanyWithYacht`, `createWarehouseFixture`, `createProductFixture`, `createStockFixture` (Task 1), `Transaction` model (already imported in Task 1's test file for assertions).
+
+- [ ] **Step 1: Add the failing tests**
+
+```js
+// =========================================================================
+// PUT /api/products/upadate/stock/:stock_id
+// =========================================================================
+
+describe('PUT /api/products/upadate/stock/:stock_id — actualizar stock', () => {
+    async function buildStockScenario(productOverrides = {}) {
+        const { company, yacht } = await createCompanyWithYacht(`StockUpCo-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const product = await createProductFixture(productOverrides);
+        const staff = await createStaffFixture();
+        const stock = await createStockFixture(product.id, warehouse.id, company.id);
+        return { company, yacht, warehouse, product, staff, stock };
+    }
+
+    it('devuelve 200 y crea una Transaction al aumentar la cantidad', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 15, min: stock.min, max: stock.max, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(200);
+
+        const transactions = await Transaction.findAll({ where: { productId: stock.productId } });
+        expect(transactions).toHaveLength(1);
+        expect(transactions[0].type).toBe('IN');
+    });
+
+    it('devuelve 400 con hashid inválido en stock_id', async () => {
+        const { staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put('/api/products/upadate/stock/not-a-hashid')
+                .send({ quantity: 15, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el stock no existe', async () => {
+        const { staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(999999)}`)
+                .send({ quantity: 15, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta quantity, sin corromper el stock existente', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ min: 9, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+
+        const refreshed = await Stock.findByPk(stock.id);
+        expect(Number(refreshed.quantity)).toBe(Number(stock.quantity));
+
+        const transactions = await Transaction.findAll({ where: { productId: stock.productId } });
+        expect(transactions).toHaveLength(0);
+    });
+
+    it('devuelve 400 cuando quantity no es numérico', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 'abc', responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta responsable', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 15, userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).put('/api/products/upadate/stock/any-id').send({});
+
+        expect(response.status).toBe(403);
+    });
+});
+```
+
+- [ ] **Step 2: Run and confirm the new failure modes**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand -t "actualizar stock"`
+Expected: FAIL on "hashid inválido" (`data.userId`/`stock_id` decode
+unguarded today), "no existe" (`response.body.error` shape doesn't exist —
+today it's a generic `Error` message string, not `{error:{code:...}}`),
+"falta quantity" / "no es numérico" / "falta responsable" (today these throw
+raw Sequelize/MySQL errors without `response.body.error.code`).
+
+- [ ] **Step 3: Add explicit validation and `AppError` 404 in the service**
+
+Modify `src/services/operations/inventory/products.services.js:277-358`,
+only the opening validation and the not-found throw change:
+
+```js
+    static async updateStock(id, data) {
+        if (data.quantity === undefined || data.quantity === null || !Number.isFinite(Number(data.quantity))) {
+            throw new AppError('quantity inválida', 400);
+        }
+        if (!data.responsable) {
+            throw new AppError('responsable es requerido', 400);
+        }
+
+        const t = await db.transaction();
+
+        try {
+            const current = await Stock.findByPk(id, { transaction: t });
+
+            if (!current) {
+                throw new AppError('Stock no encontrado', 404);
+            }
+
+            const currentPlain = current.get({ plain: true });
+
+            const hasChanges = Object.keys(data).some(key => {
+                return data[key] !== currentPlain[key];
+            });
+
+            if (!hasChanges) {
+                await t.rollback();
+                return;
+            }
+
+            const product = await Product.findOne({
+                where: { id: currentPlain.productId },
+                transaction: t,
+                lock: t.LOCK.UPDATE
+            });
+
+            const normalizedQty = Quantity.normalizeQuantity(product, data.quantity);
+
+            const hasQuantityChange =
+                normalizedQty !== undefined &&
+                normalizedQty !== currentPlain.quantity;
+
+            let diff = 0;
+            let diffNormal = 0;
+            let newQuantity = currentPlain.quantity;
+
+            if (hasQuantityChange) {
+                diff = normalizedQty - currentPlain.quantity;
+                newQuantity = normalizedQty;
+
+                diffNormal = Quantity.viewCorrectQuantity(product, diff)
+            }
+
+            await Stock.update({
+                ...data,
+                quantity: normalizedQty
+            }, {
+                where: { id },
+                transaction: t
+            });
+
+            await StockHistory.create({
+                stockId: id,
+                ...data
+            }, { transaction: t });
+
+            if (hasQuantityChange) {
+
+                const isIncrease = diff > 0;
+
+                await Transaction.create({
+                    productId: currentPlain.productId,
+                    userId: data.userId,
+                    warehouseFromId: isIncrease ? null : currentPlain.warehouseId,
+                    warehouseToId: isIncrease ? currentPlain.warehouseId : null,
+
+                    quantity: Math.abs(diffNormal),
+                    type: isIncrease ? 'IN' : 'OUT',
+
+                }, { transaction: t });
+            }
+
+            await t.commit();
+
+            return { message: 'Actualizado correctamente' };
+
+        } catch (error) {
+            await t.rollback();
+            throw error;
+        }
+    }
+```
+
+- [ ] **Step 4: Add `decodeId` and `next(error)` in the controller**
+
+Modify `src/controllers/operations/inventory/products.controller.js:139-150`:
+
+```js
+const updateStock = async (req, res, next) => {
+    try {
+        const stockId = decodeId(req.params.stock_id, 'stock_id');
+        const data = req.body
+        data.userId = decodeId(data.userId, 'userId');
+        await ProductService.updateStock(stockId, data);
+        res.status(200).json({ data: 'resource updated successfully' });
+    } catch (error) {
+        next(error);
+    }
+}
+```
+
+- [ ] **Step 5: Run and confirm all pass**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand`
+Expected: PASS (38 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/domain/operations-inventory-products/products.test.js src/controllers/operations/inventory/products.controller.js src/services/operations/inventory/products.services.js
+git commit -m "test+fix: updateStock valida hashids, quantity/responsable, y responde 404 explícito"
+```
+
+---
+
+### Task 10: Verificación final del dominio y de la suite completa
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the domain suite three times in isolation to rule out flakiness**
+
+Run: `npx jest tests/domain/operations-inventory-products --runInBand` (three times)
+Expected: PASS (38 tests) all three times, matching the verification bar
+used by `downloads`/`yachtRequest`.
+
+- [ ] **Step 2: Run the full repo test suite to confirm no cross-domain regressions**
+
+Run: `npx jest --runInBand`
+Expected: all suites PASS, including `tests/domain/operations-orders`,
+`tests/domain/operations-yacht-request`, and `tests/smoke/orders.smoke.test.js`.
+
+- [ ] **Step 3: Re-read the diff against the spec's contract table**
+
+Manually check `git diff main...refactor/fase-2-inventory-products -- src/controllers/operations/inventory/products.controller.js src/services/operations/inventory/products.services.js` against the "Contrato HTTP" table in `docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md` — every row must have a corresponding test from Tasks 1-9.
+
+- [ ] **Step 4: Update the spec status**
+
+Modify `docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md:4`:
+
+```
+**Estado:** Implementado
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+git commit -m "docs: marcar spec de inventory/products como implementado"
+```
+
+At this point the domain is done and green. Publishing the branch and
+opening the PR against `trunk` (per `docs/CONVENTIONS.md`'s "Flujo Git por
+dominio") is a separate, explicit step — confirm with the user before
+pushing or opening the PR.

--- a/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
+++ b/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
@@ -1407,17 +1407,20 @@ used by `downloads`/`yachtRequest`.
 
 - [ ] **Step 2: Run the full repo test suite to confirm no cross-domain regressions**
 
-Run: `npx jest --runInBand --testPathIgnorePatterns='/\.claude/'`
+Run: `npx jest --runInBand --roots tests`
 Expected: all suites PASS, including `tests/domain/operations-orders`,
 `tests/domain/operations-yacht-request`, and `tests/smoke/orders.smoke.test.js`.
-The `--testPathIgnorePatterns` flag is required — a bare `npx jest
---runInBand` also sweeps up `.claude/worktrees/*/tests/**/*.test.js` from
-unrelated leftover worktrees (the repo's `testMatch` is
-`**/tests/**/*.test.js`), which can fail for reasons that have nothing to do
-with this domain. A positional path argument like `npx jest ./tests` does
-**not** exclude it either — Jest treats positional args as a substring/regex
-filter over the full resolved paths, and `.claude/worktrees/.../tests/...`
-still contains `/tests/`, so it still matches.
+`--roots tests` is required — a bare `npx jest --runInBand` also sweeps up
+`.claude/worktrees/*/tests/**/*.test.js` from unrelated leftover worktrees
+(the repo's `testMatch` is `**/tests/**/*.test.js`), which can fail for
+reasons that have nothing to do with this domain. A positional path argument
+like `npx jest ./tests` does **not** exclude it either — Jest treats
+positional args as a substring/regex filter over the full resolved paths,
+and `.claude/worktrees/.../tests/...` still contains `/tests/`, so it still
+matches. `--testPathIgnorePatterns` was also tried and did not exclude it in
+this environment. `--roots tests` restricts Jest's file-search root instead
+of filtering after the fact, and was verified with `npx jest --listTests
+--roots tests | grep -c '\.claude'` → `0`.
 
 - [ ] **Step 3: Re-read the diff against the spec's contract table**
 

--- a/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
+++ b/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
@@ -1407,13 +1407,17 @@ used by `downloads`/`yachtRequest`.
 
 - [ ] **Step 2: Run the full repo test suite to confirm no cross-domain regressions**
 
-Run: `npx jest ./tests --runInBand`
+Run: `npx jest --runInBand --testPathIgnorePatterns='/\.claude/'`
 Expected: all suites PASS, including `tests/domain/operations-orders`,
 `tests/domain/operations-yacht-request`, and `tests/smoke/orders.smoke.test.js`.
-Scope to `./tests` explicitly — a bare `npx jest --runInBand` also sweeps up
-`.claude/worktrees/*/tests/**/*.test.js` from unrelated leftover worktrees
-(the repo's `testMatch` is `**/tests/**/*.test.js`), which can fail for
-reasons that have nothing to do with this domain.
+The `--testPathIgnorePatterns` flag is required — a bare `npx jest
+--runInBand` also sweeps up `.claude/worktrees/*/tests/**/*.test.js` from
+unrelated leftover worktrees (the repo's `testMatch` is
+`**/tests/**/*.test.js`), which can fail for reasons that have nothing to do
+with this domain. A positional path argument like `npx jest ./tests` does
+**not** exclude it either — Jest treats positional args as a substring/regex
+filter over the full resolved paths, and `.claude/worktrees/.../tests/...`
+still contains `/tests/`, so it still matches.
 
 - [ ] **Step 3: Re-read the diff against the spec's contract table**
 

--- a/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
+++ b/docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md
@@ -1407,9 +1407,13 @@ used by `downloads`/`yachtRequest`.
 
 - [ ] **Step 2: Run the full repo test suite to confirm no cross-domain regressions**
 
-Run: `npx jest --runInBand`
+Run: `npx jest ./tests --runInBand`
 Expected: all suites PASS, including `tests/domain/operations-orders`,
 `tests/domain/operations-yacht-request`, and `tests/smoke/orders.smoke.test.js`.
+Scope to `./tests` explicitly — a bare `npx jest --runInBand` also sweeps up
+`.claude/worktrees/*/tests/**/*.test.js` from unrelated leftover worktrees
+(the repo's `testMatch` is `**/tests/**/*.test.js`), which can fail for
+reasons that have nothing to do with this domain.
 
 - [ ] **Step 3: Re-read the diff against the spec's contract table**
 

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -91,6 +91,16 @@ Cambios puntuales por endpoint:
    error de sintaxis en vez de un 400 claro. Con `decodeId` validando antes
    de llegar al service, este caso nunca alcanza el `Sequelize.literal`.
 
+4. **`affectedRows` no verificado en `updateProduct` y `switchConfirguration`:**
+   `Product.update(...)` y `ProductConfiguration.update(...)` devuelven
+   `[affectedRowsCount]` — un array, siempre truthy en JavaScript incluso
+   cuando `affectedRowsCount` es `0`. Ninguno de los dos controllers revisa
+   este valor, así que actualizar un `product_id`/`configuration_id`
+   inexistente responde 200 "actualizado" sin haber tocado ninguna fila. El
+   propio dominio `yachtRequest` (mismo repo) ya estandarizó el fix: `if
+   (affectedRows === 0) throw new AppError('... no encontrado', 404)`. Se
+   aplica el mismo patrón aquí para ambos endpoints.
+
 ## Contrato HTTP
 
 La respuesta exitosa no cambia de forma. Los errores usan el estándar
@@ -109,6 +119,8 @@ central:
 | `sku` ausente en create/update | 400 (accidental, `TypeError`) | 400 (explícito, `AppError`) |
 | `Stock` no encontrado en `updateStock` | 400 (accidental) | 404 |
 | `quantity`/`responsable` inválidos en `updateStock` | 400 (accidental, error crudo de MySQL/Sequelize) | 400 (explícito, `AppError`) |
+| `product_id` inexistente en `updateProduct` | 200 (silencioso, 0 filas afectadas) | 404 |
+| `configuration_id` inexistente en `switchConfirguration` | 200 (silencioso, 0 filas afectadas) | 404 |
 | Error inesperado (DB, etc.) | 400 | 500 |
 
 ## Cambios conscientes de contrato
@@ -119,6 +131,8 @@ central:
   el modelo Sequelize permite `sku: null`. En la práctica el frontend siempre
   lo envía; el cambio solo formaliza esa expectativa con un `AppError`
   explícito en vez de un `TypeError` accidental.
+- `updateProduct` y `switchConfirguration` pasan de 200 silencioso a 404 sobre
+  un id inexistente, consistente con el patrón ya usado en `yachtRequest`.
 - El resto de la forma de respuesta exitosa (incluyendo paths, query params y
   nombres de campos) no cambia.
 
@@ -147,6 +161,9 @@ planeada:
   de 500), y verificación de que `Stock.quantity` no cambia y no se crea
   ninguna `Transaction`.
 - `updateStock` con `responsable` ausente → 400 explícito.
+- `updateProduct` sobre `product_id` inexistente → 404 (antes: 200 silencioso).
+- `switchConfirguration` sobre `configuration_id` inexistente → 404 (antes:
+  200 silencioso).
 - PK-encoding: `getProduct` devuelve `id` como hashid, no como entero crudo.
 - JWT ausente → 403.
 

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -132,7 +132,7 @@ central:
 |---|---|---:|
 | Token ausente o inválido | 403 | 403 (sin cambio) |
 | `findProduct` sin resultado | 400 | 404 |
-| Hashid inválido en cualquier param | 500 / comportamiento indefinido | 400 |
+| Hashid inválido en cualquier param | 400 (mensaje crudo sin clasificar) | 400 |
 | SKU duplicado en `createProduct` | 400 (accidental, vía excepción) | 400 (explícito, `AppError`) |
 | `sku` ausente en create/update | 400 (accidental, `TypeError`) | 400 (explícito, `AppError`) |
 | `Stock` no encontrado en `updateStock` | 400 (accidental) | 404 |
@@ -142,6 +142,7 @@ central:
 | `product_id` inexistente en `getProduct` | 200 con `null` | 404 |
 | `product_id` inexistente en `deleteProduct` | 200 con `data: undefined` | 404 |
 | Error inesperado (DB, etc.) | 400 | 500 |
+| `userId` ausente en `updateStock` | 200 (min/max-only update succeeded silently without attributing a user) | 400 |
 
 ## Cambios conscientes de contrato
 
@@ -154,6 +155,18 @@ central:
 - `updateProduct`, `switchConfirguration`, `getProduct` y `deleteProduct`
   pasan de 200 silencioso a 404 sobre un id inexistente, consistente con el
   patrón ya usado en `yachtRequest`.
+- `getProduct` (`GET /api/products/:product_id`) ahora devuelve `id` como
+  hashid (string) en vez del id numérico crudo — ver "Bug 1: PK-encoding
+  no-op" más arriba; se registra también aquí por ser un cambio de forma de
+  respuesta visible para el consumidor.
+- `updateStock` ahora exige `userId` en **toda** llamada, no solo en las que
+  modifican `quantity`: el controller decodifica `data.userId` de forma
+  incondicional con `decodeId`, así que un update de solo `min`/`max` que
+  antes podía pasar con `userId` ausente (200, sin atribuir el cambio a
+  nadie, porque `Transaction.create` — el único consumidor de `userId` — ni
+  siquiera se invocaba) ahora responde `400`. Es un endurecimiento de
+  contrato intencional: toda modificación de stock, incluidas las de solo
+  `min`/`max`, debe quedar atribuida a un usuario.
 - El resto de la forma de respuesta exitosa (incluyendo paths, query params y
   nombres de campos) no cambia.
 
@@ -218,3 +231,20 @@ hallazgo fuera de alcance.
   `CLIENT_FOUND_ROWS` reporta `affectedRows: 0` en ese caso. No se toca aquí
   por ser un dominio ya cerrado, pero queda registrado para un futuro fix en
   `yachtRequest`.
+- `ProductConfiguration.update(data, ...)` (en `switchConfirguration`) y
+  `Stock.update({ ...data, quantity }, ...)` (en `updateStock`) pasan el
+  body de la petición directo a `update` de Sequelize, permitiendo que un
+  cliente setee campos que no deberían ser escribibles (p. ej. `productId`,
+  `companyId`, `warehouseId`) — mass assignment. Es comportamiento
+  preexistente, no relacionado con este retrofit; queda fuera de alcance
+  arreglarlo aquí.
+- `ProductService.delete` (en `products.services.js`) llama a
+  `Product.destroy(...)` directamente; si el producto tiene `stocks` o
+  `transactions` dependientes (sin `ON DELETE CASCADE` en esas
+  asociaciones), MySQL lanza un error de constraint de FK que `next(error)`
+  clasifica como 500 con un mensaje crudo de la DB, en vez de un 4xx claro
+  como "no se puede eliminar un producto con stock o movimientos
+  asociados". Es un gap real pero se juzgó razonable diferirlo como
+  seguimiento nombrado en vez de arreglarlo en este pase; el fix probable a
+  futuro es envolver el `destroy` en un `try/catch` de
+  `SequelizeForeignKeyConstraintError` y lanzar `AppError(msg, 409)`.

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -15,9 +15,10 @@ separados del subárbol `operations/inventory`, igual que se hizo con
 `catalogs` y `rrhh`.
 
 El objetivo es adoptar `AppError`/`next(error)`, clasificar correctamente
-400, 404 y 500, corregir un bug de PK-encoding recurrente, corregir una
-corrupción de datos en `updateStock`, y cubrir el dominio con tests reales de
-DB.
+400, 404 y 500 (incluyendo cuatro endpoints que hoy responden 200 sobre un id
+inexistente), corregir un bug de PK-encoding recurrente, corregir una
+regresión de clasificación de errores en `updateStock`, y cubrir el dominio
+con tests reales de DB.
 
 ## Diseño
 

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -91,15 +91,24 @@ Cambios puntuales por endpoint:
    error de sintaxis en vez de un 400 claro. Con `decodeId` validando antes
    de llegar al service, este caso nunca alcanza el `Sequelize.literal`.
 
-4. **`affectedRows` no verificado en `updateProduct` y `switchConfirguration`:**
-   `Product.update(...)` y `ProductConfiguration.update(...)` devuelven
-   `[affectedRowsCount]` — un array, siempre truthy en JavaScript incluso
-   cuando `affectedRowsCount` es `0`. Ninguno de los dos controllers revisa
-   este valor, así que actualizar un `product_id`/`configuration_id`
-   inexistente responde 200 "actualizado" sin haber tocado ninguna fila. El
-   propio dominio `yachtRequest` (mismo repo) ya estandarizó el fix: `if
-   (affectedRows === 0) throw new AppError('... no encontrado', 404)`. Se
-   aplica el mismo patrón aquí para ambos endpoints.
+4. **Operaciones sobre id inexistente responden 200 en vez de 404, en cuatro
+   endpoints:**
+   - `updateProduct`: `Product.update(...)` devuelve `[affectedRowsCount]` —
+     un array, siempre truthy en JavaScript incluso cuando
+     `affectedRowsCount` es `0`. El controller nunca revisa este valor.
+   - `switchConfirguration`: mismo problema con
+     `ProductConfiguration.update(...)`.
+   - `getProduct`: `ProductService.getProductById` devuelve `null` si no
+     existe; el controller lo serializa igual con `res.status(200)`.
+   - `deleteProduct`: `Product.destroy(...)` devuelve `0` (falsy) si no hay
+     coincidencia; el service retorna `undefined` en ese caso y el
+     controller responde `200 { data: undefined }`.
+
+   El propio dominio `yachtRequest` (mismo repo) ya estandarizó el fix para
+   este patrón: `if (affectedRows === 0) throw new AppError('... no
+   encontrado', 404)` / `if (!result) throw new AppError(..., 404)`. Se
+   aplica el mismo idiom aquí, consistente con el objetivo explícito de este
+   retrofit (clasificar correctamente 400/404/500).
 
 ## Contrato HTTP
 
@@ -121,6 +130,8 @@ central:
 | `quantity`/`responsable` inválidos en `updateStock` | 400 (accidental, error crudo de MySQL/Sequelize) | 400 (explícito, `AppError`) |
 | `product_id` inexistente en `updateProduct` | 200 (silencioso, 0 filas afectadas) | 404 |
 | `configuration_id` inexistente en `switchConfirguration` | 200 (silencioso, 0 filas afectadas) | 404 |
+| `product_id` inexistente en `getProduct` | 200 con `null` | 404 |
+| `product_id` inexistente en `deleteProduct` | 200 con `data: undefined` | 404 |
 | Error inesperado (DB, etc.) | 400 | 500 |
 
 ## Cambios conscientes de contrato
@@ -131,8 +142,9 @@ central:
   el modelo Sequelize permite `sku: null`. En la práctica el frontend siempre
   lo envía; el cambio solo formaliza esa expectativa con un `AppError`
   explícito en vez de un `TypeError` accidental.
-- `updateProduct` y `switchConfirguration` pasan de 200 silencioso a 404 sobre
-  un id inexistente, consistente con el patrón ya usado en `yachtRequest`.
+- `updateProduct`, `switchConfirguration`, `getProduct` y `deleteProduct`
+  pasan de 200 silencioso a 404 sobre un id inexistente, consistente con el
+  patrón ya usado en `yachtRequest`.
 - El resto de la forma de respuesta exitosa (incluyendo paths, query params y
   nombres de campos) no cambia.
 
@@ -164,8 +176,18 @@ planeada:
 - `updateProduct` sobre `product_id` inexistente → 404 (antes: 200 silencioso).
 - `switchConfirguration` sobre `configuration_id` inexistente → 404 (antes:
   200 silencioso).
+- `getProduct` sobre `product_id` inexistente → 404 (antes: 200 con `null`).
+- `deleteProduct` sobre `product_id` inexistente → 404 (antes: 200 con
+  `data: undefined`).
 - PK-encoding: `getProduct` devuelve `id` como hashid, no como entero crudo.
 - JWT ausente → 403.
+
+Nota: los dos ítems de `getProduct`/`deleteProduct` no formaban parte de la
+pregunta inicial sobre contrato, pero surgieron durante la revisión
+sistemática del patrón `if (!result) throw AppError 404` contra los diez
+endpoints y son directamente el objetivo declarado del retrofit (clasificar
+400/404/500 correctamente); se documentan aquí en vez de dejarlos como
+hallazgo fuera de alcance.
 
 ## Hallazgos fuera de alcance
 

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -1,0 +1,145 @@
+# Fase 2 — Dominio Inventory/Products — diseño
+
+**Fecha:** 2026-08-20
+**Estado:** Diseño aprobado, pendiente de implementación
+
+## Contexto y alcance
+
+El dominio expone diez rutas protegidas bajo `/api/products`
+(`authJwt.verifyToken`, sin `isAdmin`), implementadas en
+`products.controller.js` / `products.services.js` / `products.routes.js`.
+Cubre CRUD de productos, sus configuraciones por pax, consulta de stock por
+warehouse y actualización de stock con generación de transacciones. No se
+tocan `registers`, `transactions` ni `warehouse` — quedan como dominios
+separados del subárbol `operations/inventory`, igual que se hizo con
+`catalogs` y `rrhh`.
+
+El objetivo es adoptar `AppError`/`next(error)`, clasificar correctamente
+400, 404 y 500, corregir un bug de PK-encoding recurrente, corregir una
+corrupción de datos en `updateStock`, y cubrir el dominio con tests reales de
+DB.
+
+## Diseño
+
+Retrofit completo a `AppError` + `next(error)` en los diez handlers del
+controller. Se agrega un helper local `decodeId` (mismo patrón que
+`downloads`/`yachtRequest`) que valida los hashids de `product_id`,
+`warehouse_id`, `stock_id` y `data.userId` antes de que lleguen a Sequelize o
+a SQL crudo — `decode` puede devolver `undefined` ante una entrada
+malformada, y hoy ese `undefined` se propaga sin control.
+
+Cambios puntuales por endpoint:
+
+- `findProduct`: sin resultado → `AppError(msg, 404)` en vez de 400.
+- `createProduct`: `sku` ausente → `AppError('sku requerido', 400)` explícito
+  en vez de un `TypeError` accidental por `.replace()` sobre `undefined`.
+  SKU duplicado → `AppError(msg, 400)` en vez de `Error` genérico (que hoy
+  cae en 400 por el catch-all, pero dejaría de hacerlo al migrar a
+  `next(error)`).
+- `updateProduct`: mismo guard de `sku` requerido que `createProduct`.
+- `getProduct`, `updateProduct`, `deleteProduct`, `getProductsByWarehouse`,
+  `updateStock`: hashid inválido en cualquier parámetro → `AppError(msg,
+  400)` vía `decodeId`, en vez de propagar `undefined`.
+- `updateStock`: `Stock` no encontrado → `AppError('Stock no encontrado',
+  404)` en vez de `Error` genérico.
+- Resto de errores no identificables (fallo de DB, etc.) se delegan tal cual
+  con `next(error)`; `errorHandler` los clasifica como 500.
+
+## Bugs a corregir
+
+1. **PK-encoding no-op en `getProduct`:** `result.id = Utils.encode(result.id)`
+   sin `.dataValues` — la asignación no se refleja en el JSON serializado por
+   `res.json`, así que el endpoint devuelve el id numérico crudo en vez del
+   hashid. Mismo bug ya documentado independientemente en `catalogs` y
+   `rrhh/trading` (ver `docs/CONVENTIONS.md`). Fix:
+   `result.dataValues.id = Utils.encode(result.dataValues.id)`.
+
+2. **Corrupción de datos en `updateStock`:** `normalizeQuantity(product,
+   data.quantity)` se invoca incondicionalmente aunque `data.quantity` no
+   venga en el payload (por ejemplo, al actualizar solo `min`/`max`). Para
+   productos `DISCRETE`, `normalizeQuantity` hace `Number(undefined)` →
+   `NaN`. La comparación posterior `normalizedQty !== undefined &&
+   normalizedQty !== currentPlain.quantity` es `true` para `NaN` (nunca es
+   igual a nada, ni siquiera a sí mismo), así que el flujo trata esto como un
+   cambio real: escribe `Stock.quantity = NaN` y crea una `Transaction`
+   fantasma con `quantity: NaN` y `type: 'OUT'`. Fix: solo normalizar y
+   calcular el diff cuando `data.quantity !== undefined`.
+
+3. **SQL crudo sin validar `warehouseId`** en `getProductsByWarehouse`: el id
+   decodificado se interpola directo en tres `Sequelize.literal(...)` para
+   las subconsultas de `totalIncome`/`totalOutcome`/`totalBarConsumption`.
+   Hoy, un `warehouse_id` con hashid malformado produce `undefined`
+   interpolado como literal SQL (`= undefined`), rompiendo la consulta con un
+   error de sintaxis en vez de un 400 claro. Con `decodeId` validando antes
+   de llegar al service, este caso nunca alcanza el `Sequelize.literal`.
+
+## Contrato HTTP
+
+La respuesta exitosa no cambia de forma. Los errores usan el estándar
+central:
+
+```json
+{ "error": { "message": "mensaje descriptivo", "code": "AppError|INTERNAL_ERROR" } }
+```
+
+| Caso | Antes | Después |
+|---|---|---:|
+| Token ausente o inválido | 403 | 403 (sin cambio) |
+| `findProduct` sin resultado | 400 | 404 |
+| Hashid inválido en cualquier param | 500 / comportamiento indefinido | 400 |
+| SKU duplicado en `createProduct` | 400 (accidental, vía excepción) | 400 (explícito, `AppError`) |
+| `sku` ausente en create/update | 400 (accidental, `TypeError`) | 400 (explícito, `AppError`) |
+| `Stock` no encontrado en `updateStock` | 400 (accidental) | 404 |
+| Error inesperado (DB, etc.) | 400 | 500 |
+
+## Cambios conscientes de contrato
+
+- `findProduct` pasa de 400 a 404 para "no encontrado" — consistente con el
+  resto de dominios retrofiteados.
+- `sku` pasa a ser requerido en el contrato de creación/actualización, aunque
+  el modelo Sequelize permite `sku: null`. En la práctica el frontend siempre
+  lo envía; el cambio solo formaliza esa expectativa con un `AppError`
+  explícito en vez de un `TypeError` accidental.
+- El resto de la forma de respuesta exitosa (incluyendo paths, query params y
+  nombres de campos) no cambia.
+
+## Seguridad preservada
+
+`/api/products` sigue protegido únicamente por `authJwt.verifyToken`, sin
+agregar ni retirar roles. `decodeId` es endurecimiento de validación de
+entrada, no un cambio de política de autorización.
+
+## Verificación
+
+Nueva suite `tests/domain/operations-inventory-products/products.test.js`
+(Sequelize real, siguiendo el patrón de `orders`/`yachtRequest`). Cobertura
+planeada:
+
+- Happy path de los diez endpoints (`getProducts`, `getProduct`,
+  `findProduct`, `getProductsWithConfigurations`, `getProductsByWarehouse`,
+  `createProduct`, `updateProduct`, `deleteProduct`,
+  `switchConfirguration`, `updateStock`).
+- Hashid inválido en cada parámetro que lo usa → 400.
+- `findProduct` sin resultado → 404.
+- SKU duplicado en `createProduct` → 400.
+- `sku` ausente en create/update → 400.
+- `updateStock` sobre `stock_id` inexistente → 404.
+- Regresión específica del bug `NaN`: `updateStock` actualizando solo
+  `min`/`max` sobre un producto `DISCRETE`, verificando que `quantity` no
+  cambie y no se cree una `Transaction`.
+- PK-encoding: `getProduct` devuelve `id` como hashid, no como entero crudo.
+- JWT ausente → 403.
+
+## Hallazgos fuera de alcance
+
+- `switchConfirguration` no valida que `configuration_id` pertenezca a un
+  producto existente ni decodifica el id (los ids de `ProductConfiguration`
+  no se hashid-encodean en las respuestas, a diferencia de `Product`) — se
+  mantiene el comportamiento actual, fuera del alcance de este retrofit.
+- `updateProduct` reemplaza/borra configuraciones dentro de la misma
+  transacción sin validar que las `id` entrantes en `configurations`
+  pertenezcan al producto que se está actualizando — mismo patrón de riesgo
+  documentado en `CONVENTIONS.md` ("Validación de relaciones en payloads"),
+  pero no se aborda aquí para no ampliar el alcance del dominio.
+- `productsBar.controller.js` / `productsBar.services.js` (dominio `bar`) es
+  un dominio distinto que también maneja productos; no se toca.

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -54,16 +54,34 @@ Cambios puntuales por endpoint:
    `rrhh/trading` (ver `docs/CONVENTIONS.md`). Fix:
    `result.dataValues.id = Utils.encode(result.dataValues.id)`.
 
-2. **Corrupción de datos en `updateStock`:** `normalizeQuantity(product,
-   data.quantity)` se invoca incondicionalmente aunque `data.quantity` no
-   venga en el payload (por ejemplo, al actualizar solo `min`/`max`). Para
-   productos `DISCRETE`, `normalizeQuantity` hace `Number(undefined)` →
-   `NaN`. La comparación posterior `normalizedQty !== undefined &&
-   normalizedQty !== currentPlain.quantity` es `true` para `NaN` (nunca es
-   igual a nada, ni siquiera a sí mismo), así que el flujo trata esto como un
-   cambio real: escribe `Stock.quantity = NaN` y crea una `Transaction`
-   fantasma con `quantity: NaN` y `type: 'OUT'`. Fix: solo normalizar y
-   calcular el diff cuando `data.quantity !== undefined`.
+2. **Regresión de clasificación de errores en `updateStock`** (corregido tras
+   verificación empírica contra la DB real; ver nota abajo): `updateStock` no
+   valida explícitamente que `quantity` sea un número finito ni que
+   `responsable` esté presente antes de tocar la base de datos. Hoy, un
+   payload inválido (falta `quantity`, falta `responsable`, o `quantity` no
+   numérico) revienta con un error crudo de Sequelize/MySQL —
+   `SequelizeValidationError` (`notNull Violation: stock_history.quantity
+   cannot be null`) o `SequelizeDatabaseError` (`Incorrect integer value:
+   'abc' for column 'quantity'`) — que el catch-all actual reporta como 400
+   por accidente, exponiendo además el mensaje técnico crudo de MySQL. La
+   transacción protege la integridad: verificado empíricamente que ante
+   ambos payloads inválidos `Stock.quantity` permanece sin cambios y no se
+   crea ninguna `Transaction` (rollback completo). Pero **al migrar a
+   `next(error)` sin agregar validación explícita, estos errores no
+   clasificados caerían a 500** en vez de 400 — una regresión respecto al
+   comportamiento actual. Fix: validar explícitamente `quantity` (número
+   finito) y `responsable` (string no vacío) al inicio de `updateStock` y
+   lanzar `AppError(msg, 400)` antes de tocar la base de datos.
+
+   > **Nota de verificación:** la versión original de este documento describía
+   > este punto como una corrupción silenciosa (`Stock.quantity = NaN`
+   > persistido). Se verificó empíricamente con un script contra la DB real
+   > que la transacción de Sequelize revierte por completo en ambos casos
+   > (`quantity` ausente y `quantity` no numérico) gracias a las columnas
+   > `NOT NULL`/tipadas de `stock_history`, así que no hay corrupción
+   > persistente. El hallazgo se corrigió a lo que sí se comprobó: una
+   > regresión de clasificación de errores (400 accidental hoy → 500 tras el
+   > retrofit si no se agrega validación explícita).
 
 3. **SQL crudo sin validar `warehouseId`** en `getProductsByWarehouse`: el id
    decodificado se interpola directo en tres `Sequelize.literal(...)` para
@@ -90,6 +108,7 @@ central:
 | SKU duplicado en `createProduct` | 400 (accidental, vía excepción) | 400 (explícito, `AppError`) |
 | `sku` ausente en create/update | 400 (accidental, `TypeError`) | 400 (explícito, `AppError`) |
 | `Stock` no encontrado en `updateStock` | 400 (accidental) | 404 |
+| `quantity`/`responsable` inválidos en `updateStock` | 400 (accidental, error crudo de MySQL/Sequelize) | 400 (explícito, `AppError`) |
 | Error inesperado (DB, etc.) | 400 | 500 |
 
 ## Cambios conscientes de contrato
@@ -124,9 +143,10 @@ planeada:
 - SKU duplicado en `createProduct` → 400.
 - `sku` ausente en create/update → 400.
 - `updateStock` sobre `stock_id` inexistente → 404.
-- Regresión específica del bug `NaN`: `updateStock` actualizando solo
-  `min`/`max` sobre un producto `DISCRETE`, verificando que `quantity` no
-  cambie y no se cree una `Transaction`.
+- `updateStock` con `quantity` ausente o no numérico → 400 explícito (en vez
+  de 500), y verificación de que `Stock.quantity` no cambia y no se crea
+  ninguna `Transaction`.
+- `updateStock` con `responsable` ausente → 400 explícito.
 - PK-encoding: `getProduct` devuelve `id` como hashid, no como entero crudo.
 - JWT ausente → 403.
 

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -104,11 +104,19 @@ Cambios puntuales por endpoint:
      coincidencia; el service retorna `undefined` en ese caso y el
      controller responde `200 { data: undefined }`.
 
-   El propio dominio `yachtRequest` (mismo repo) ya estandarizó el fix para
-   este patrón: `if (affectedRows === 0) throw new AppError('... no
-   encontrado', 404)` / `if (!result) throw new AppError(..., 404)`. Se
-   aplica el mismo idiom aquí, consistente con el objetivo explícito de este
-   retrofit (clasificar correctamente 400/404/500).
+   Fix: `getProduct` y `deleteProduct` ya siguen (o pasan a seguir) el patrón
+   `if (!result) throw new AppError(..., 404)`. Para `updateProduct` y
+   `switchConfirguration` **no** se usa `affectedRows` como señal de
+   "no encontrado": se verificó empíricamente contra la DB real que MySQL
+   reporta `affectedRows: 0` tanto cuando el id no existe como cuando existe
+   pero los valores enviados son idénticos a los actuales (update
+   idempotente, sin `CLIENT_FOUND_ROWS` habilitado en la conexión de
+   `src/utils/database.js`). Usar `affectedRows === 0 → 404` produciría
+   falsos 404 en actualizaciones legítimas sin cambios reales. En su lugar,
+   ambos endpoints adoptan el patrón "buscar primero" que ya usa
+   `updateStock` en este mismo archivo: `findByPk` antes del `update`, y
+   `AppError(..., 404)` si no existe, independientemente de cuántas filas
+   reporte `affectedRows`.
 
 ## Contrato HTTP
 
@@ -202,3 +210,10 @@ hallazgo fuera de alcance.
   pero no se aborda aquí para no ampliar el alcance del dominio.
 - `productsBar.controller.js` / `productsBar.services.js` (dominio `bar`) es
   un dominio distinto que también maneja productos; no se toca.
+- `YachtRequestController.updateRequest` (`yachtRequest`, ya mergeado) usa
+  `if (affectedRows === 0) throw AppError(..., 404)`. Verificado
+  empíricamente en este dominio que ese patrón da falso 404 ante un update
+  idempotente (valores enviados idénticos a los actuales), porque MySQL sin
+  `CLIENT_FOUND_ROWS` reporta `affectedRows: 0` en ese caso. No se toca aquí
+  por ser un dominio ya cerrado, pero queda registrado para un futuro fix en
+  `yachtRequest`.

--- a/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
+++ b/docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md
@@ -1,7 +1,7 @@
 # Fase 2 — Dominio Inventory/Products — diseño
 
 **Fecha:** 2026-08-20
-**Estado:** Diseño aprobado, pendiente de implementación
+**Estado:** Implementado
 
 ## Contexto y alcance
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -143,16 +143,15 @@ const switchConfirguration = async (req, res, next) => {
     }
 }
 
-const updateStock = async (req, res) => {
+const updateStock = async (req, res, next) => {
     try {
-
-        const stockId = Utils.decode(req.params.stock_id);
+        const stockId = decodeId(req.params.stock_id, 'stock_id');
         const data = req.body
-        data.userId = Utils.decode(data.userId);
+        data.userId = decodeId(data.userId, 'userId');
         await ProductService.updateStock(stockId, data);
         res.status(200).json({ data: 'resource updated successfully' });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -91,17 +91,19 @@ const getProduct = async (req, res, next) => {
     }
 }
 
-const createProduct = async (req, res) => {
+const createProduct = async (req, res, next) => {
     try {
         const product = req.body;
+        if (!product.sku) {
+            throw new AppError('sku es requerido', 400);
+        }
         product.sku = product.sku.replace(/^0+/, '');
         const result = await ProductService.createProduct(product);
         if (result) {
             res.status(200).json({ data: 'resource created successfully' });
         }
     } catch (error) {
-
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -41,7 +41,7 @@ const getProducts = async (req, res, next) => {
     }
 }
 
-const getProductsWithConfigurations = async (req, res) => {
+const getProductsWithConfigurations = async (req, res, next) => {
     try {
         const result = await ProductService.getProductsWithConfigurations();
         if (result instanceof Array) {
@@ -53,7 +53,7 @@ const getProductsWithConfigurations = async (req, res) => {
         }
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -122,14 +122,13 @@ const updateProduct = async (req, res, next) => {
     }
 }
 
-const deleteProduct = async (req, res) => {
+const deleteProduct = async (req, res, next) => {
     try {
-        const productId = Utils.decode(req.params.product_id);
+        const productId = decodeId(req.params.product_id, 'product_id');
         const result = await ProductService.delete(productId);
         res.status(200).json({ data: result })
     } catch (error) {
-
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -133,19 +133,14 @@ const deleteProduct = async (req, res, next) => {
 }
 
 
-const switchConfirguration = async (req, res) => {
+const switchConfirguration = async (req, res, next) => {
     try {
-
         const configurationId = req.params.configuration_id;
         const data = req.body
-        const result = await ProductService.switchConfirguration(data, {
-            where: { id: configurationId }
-        });
-        if (result) {
-            res.status(200).json({ data: 'resource updated successfully' });
-        }
+        await ProductService.switchConfirguration(data, configurationId);
+        res.status(200).json({ data: 'resource updated successfully' });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -16,18 +16,14 @@ const decodeId = (value, fieldName) => {
     return id;
 };
 
-const findProduct = async (req, res) => {
+const findProduct = async (req, res, next) => {
     try {
         const sku = req.params.sku.replace(/^0+/, '');
         const result = await ProductService.findProduct(sku);
-        if (result) {
-            res.status(200).json({ data: result });
-        } else {
-            res.status(400).json(`Producto no encontrado para sku: ${sku}`)
-        }
+        if (!result) throw new AppError(`Producto no encontrado para sku: ${sku}`, 404);
+        res.status(200).json({ data: result });
     } catch (error) {
-
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -57,9 +57,9 @@ const getProductsWithConfigurations = async (req, res, next) => {
     }
 }
 
-const getProductsByWarehouse = async (req, res) => {
+const getProductsByWarehouse = async (req, res, next) => {
     try {
-        const warehouseId = Utils.decode(req.params.warehouse_id)
+        const warehouseId = decodeId(req.params.warehouse_id, 'warehouse_id');
         const result = await ProductService.getProductsByWarehouse(warehouseId);
 
         if (result instanceof Array) {
@@ -74,8 +74,7 @@ const getProductsByWarehouse = async (req, res) => {
         }
         res.status(200).json(result);
     } catch (error) {
-        console.log(error)
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -107,15 +107,18 @@ const createProduct = async (req, res, next) => {
     }
 }
 
-const updateProduct = async (req, res) => {
+const updateProduct = async (req, res, next) => {
     try {
-        const productId = Utils.decode(req.params.product_id);
+        const productId = decodeId(req.params.product_id, 'product_id');
         const product = req.body;
+        if (!product.sku) {
+            throw new AppError('sku es requerido', 400);
+        }
         product.sku = product.sku.replace(/^0+/, '');
         await ProductService.updateProduct(product, productId);
         res.status(200).json({ data: 'resource updated successfully' });
     } catch (error) {
-        res.status(400).json(error.message);
+        next(error);
     }
 }
 

--- a/src/controllers/operations/inventory/products.controller.js
+++ b/src/controllers/operations/inventory/products.controller.js
@@ -1,6 +1,20 @@
 const ProductService = require('../../../services/operations/inventory/products.services');
 const Utils = require('../../../utils/Utils');
 const Quantity = require('../../../utils/quantity');
+const AppError = require('../../../errors/AppError');
+
+const decodeId = (value, fieldName) => {
+    let id;
+    try {
+        id = Utils.decode(value);
+    } catch {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    if (!Number.isInteger(id) || id <= 0) {
+        throw new AppError(`${fieldName} inválido`, 400);
+    }
+    return id;
+};
 
 const findProduct = async (req, res) => {
     try {
@@ -17,7 +31,7 @@ const findProduct = async (req, res) => {
     }
 }
 
-const getProducts = async (req, res) => {
+const getProducts = async (req, res, next) => {
     try {
         const result = await ProductService.getAll();
         if (result instanceof Array) {
@@ -27,7 +41,7 @@ const getProducts = async (req, res) => {
         }
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 
@@ -69,16 +83,15 @@ const getProductsByWarehouse = async (req, res) => {
     }
 }
 
-const getProduct = async (req, res) => {
+const getProduct = async (req, res, next) => {
     try {
-        const productId = Utils.decode(req.params.product_id);
+        const productId = decodeId(req.params.product_id, 'product_id');
         const result = await ProductService.getProductById(productId);
-        if (result instanceof Object) {
-            result.id = Utils.encode(result.id);
-        }
+        if (!result) throw new AppError('Producto no encontrado', 404);
+        result.dataValues.id = Utils.encode(result.dataValues.id);
         res.status(200).json(result);
     } catch (error) {
-        res.status(400).json(error.message)
+        next(error);
     }
 }
 

--- a/src/routes/operations/yachtRequest/yachtRequest.routes.js
+++ b/src/routes/operations/yachtRequest/yachtRequest.routes.js
@@ -3,11 +3,201 @@ const YachtRequestController  = require ('../../../controllers/operations/yachtR
 
 const router = Router();
 
+/**
+ * @openapi
+ * /requests:
+ *   get:
+ *     summary: Listar todas las solicitudes de yate
+ *     tags: [Requests]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de solicitudes con su bodega, items y responsable
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     description: ID de solicitud codificado (hashids)
+ *                   warehouseId:
+ *                     type: string
+ *                     description: ID de bodega codificado (hashids)
+ *                   name:
+ *                     type: string
+ *                   group:
+ *                     type: string
+ *                   status:
+ *                     type: string
+ *                   warehouse:
+ *                     type: object
+ *                   requestItems:
+ *                     type: array
+ *                     items:
+ *                       type: object
+ *                   responsible:
+ *                     type: object
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       500:
+ *         description: Error inesperado
+ *   post:
+ *     summary: Crear una solicitud de yate
+ *     tags: [Requests]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [warehouseId, userId, status, products]
+ *             properties:
+ *               warehouseId:
+ *                 type: string
+ *                 description: ID de bodega codificado (hashids)
+ *               userId:
+ *                 type: string
+ *                 description: ID de staff responsable codificado (hashids)
+ *               name:
+ *                 type: string
+ *               group:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *               products:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     configurationId:
+ *                       type: integer
+ *                     stock:
+ *                       type: integer
+ *                     order:
+ *                       type: integer
+ *                     quantity:
+ *                       type: integer
+ *     responses:
+ *       200:
+ *         description: Solicitud creada
+ *       400:
+ *         description: ID codificado inválido o products no es un arreglo
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/',YachtRequestController.getAllRequests);
+
+/**
+ * @openapi
+ * /requests/{request_id}:
+ *   get:
+ *     summary: Obtener una solicitud de yate por ID
+ *     tags: [Requests]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: request_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de solicitud codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Solicitud encontrada con sus items, bodega y responsable
+ *       400:
+ *         description: ID codificado inválido
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       404:
+ *         description: Solicitud no encontrada
+ *       500:
+ *         description: Error inesperado
+ *   put:
+ *     summary: Actualizar una solicitud de yate (y opcionalmente las cantidades de sus items)
+ *     tags: [Requests]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: request_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de solicitud codificado (hashids)
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status:
+ *                 type: string
+ *               name:
+ *                 type: string
+ *               items:
+ *                 type: array
+ *                 description: Items cuya cantidad se desea actualizar
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       description: ID interno (sin codificar) del item
+ *                     quantity:
+ *                       type: integer
+ *     responses:
+ *       200:
+ *         description: Solicitud actualizada
+ *       400:
+ *         description: ID codificado inválido o cantidad de item inválida
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       404:
+ *         description: Solicitud no encontrada
+ *       500:
+ *         description: Error inesperado
+ */
 router.get('/:request_id',YachtRequestController.getRequestById);
 router.post('/', YachtRequestController.createRequest);
 router.put('/:request_id', YachtRequestController.updateRequest);
 
+/**
+ * @openapi
+ * /requests/updateRequest/{request_id}:
+ *   put:
+ *     summary: Alias de PUT /requests/{request_id} (actualizar solicitud de yate)
+ *     tags: [Requests]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: request_id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de solicitud codificado (hashids)
+ *     responses:
+ *       200:
+ *         description: Solicitud actualizada
+ *       400:
+ *         description: ID codificado inválido o cantidad de item inválida
+ *       403:
+ *         description: Token no proporcionado o inválido
+ *       404:
+ *         description: Solicitud no encontrada
+ *       500:
+ *         description: Error inesperado
+ */
 router.put('/updateRequest/:request_id', YachtRequestController.updateRequest);
 
 

--- a/src/services/operations/inventory/products.services.js
+++ b/src/services/operations/inventory/products.services.js
@@ -186,6 +186,11 @@ class ProductService {
         const transaction = await db.transaction();
 
         try {
+            const existing = await Product.findByPk(id, { transaction });
+            if (!existing) {
+                throw new AppError('Producto no encontrado', 404);
+            }
+
             const result = await Product.update(
                 {
                     name: product.name,

--- a/src/services/operations/inventory/products.services.js
+++ b/src/services/operations/inventory/products.services.js
@@ -263,9 +263,10 @@ class ProductService {
             const result = await Product.destroy({
                 where: { id: productId }
             });
-            if (result) {
-                return 'resource deleted successfully'
+            if (!result) {
+                throw new AppError('Producto no encontrado', 404);
             }
+            return 'resource deleted successfully'
         } catch (error) {
             throw error;
         }

--- a/src/services/operations/inventory/products.services.js
+++ b/src/services/operations/inventory/products.services.js
@@ -272,10 +272,14 @@ class ProductService {
         }
     }
 
-    static async switchConfirguration(data, id) {
+    static async switchConfirguration(data, configurationId) {
         try {
-            const result = await ProductConfiguration.update(data, id);
-            return result;
+            const existing = await ProductConfiguration.findByPk(configurationId);
+            if (!existing) {
+                throw new AppError('Configuración no encontrada', 404);
+            }
+            await ProductConfiguration.update(data, { where: { id: configurationId } });
+            return true;
         } catch (error) {
             throw error;
         }

--- a/src/services/operations/inventory/products.services.js
+++ b/src/services/operations/inventory/products.services.js
@@ -286,13 +286,20 @@ class ProductService {
     }
 
     static async updateStock(id, data) {
+        if (data.quantity === undefined || data.quantity === null || !Number.isFinite(Number(data.quantity))) {
+            throw new AppError('quantity inválida', 400);
+        }
+        if (!data.responsable) {
+            throw new AppError('responsable es requerido', 400);
+        }
+
         const t = await db.transaction();
 
         try {
             const current = await Stock.findByPk(id, { transaction: t });
 
             if (!current) {
-                throw new Error('Stock no encontrado');
+                throw new AppError('Stock no encontrado', 404);
             }
 
             const currentPlain = current.get({ plain: true });

--- a/src/services/operations/inventory/products.services.js
+++ b/src/services/operations/inventory/products.services.js
@@ -8,6 +8,7 @@ const { Sequelize, Op } = require('sequelize');
 const StockHistory = require('../../../models/operations/inventory/stockHistory.models');
 const Transaction = require('../../../models/operations/inventory/transaction.models');
 const Quantity = require('../../../utils/quantity');
+const AppError = require('../../../errors/AppError');
 
 class ProductService {
     static async findProduct(sku) {
@@ -158,7 +159,7 @@ class ProductService {
             });
 
             if (product) {
-                throw new Error(`El producto con el SKU: ${product.sku} ya existe`);
+                throw new AppError(`El producto con el SKU: ${product.sku} ya existe`, 400);
             }
 
             const result = await Product.create(data, { transaction });

--- a/src/services/operations/inventory/products.services.js
+++ b/src/services/operations/inventory/products.services.js
@@ -144,7 +144,6 @@ class ProductService {
             return currentPlain;
 
         } catch (error) {
-            console.log(error)
             throw error;
         }
     }

--- a/src/utils/quantity.js
+++ b/src/utils/quantity.js
@@ -1,7 +1,9 @@
+const AppError = require('../errors/AppError');
+
 function normalizeQuantity(product, quantity) {
     if (product?.type === 'CONSUMABLE') {
         if (!product.presentationQuantity) {
-            throw new Error(`Producto ${product.name} sin presentationQuantity`);
+            throw new AppError(`Producto ${product.name} sin presentationQuantity`, 400);
         }
 
         const qty = Number(quantity);
@@ -18,7 +20,7 @@ function normalizeQuantity(product, quantity) {
 function viewCorrectQuantity(product, quantity) {
     if (product?.type === 'CONSUMABLE') {
         if (!product?.presentationQuantity) {
-            throw new Error(`Producto ${product?.name} sin presentationQuantity`);
+            throw new AppError(`Producto ${product?.name} sin presentationQuantity`, 400);
         }
 
         return (quantity / product?.presentationQuantity).toFixed(2);

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -334,3 +334,42 @@ describe('PUT /api/products/updateProduct/:product_id — actualizar producto', 
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// DELETE /api/products/:product_id
+// =========================================================================
+
+describe('DELETE /api/products/:product_id — eliminar producto', () => {
+    it('devuelve 200 al eliminar el producto', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app).delete(`/api/products/${Utils.encode(product.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource deleted successfully');
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(request(app).delete('/api/products/not-a-hashid'));
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el producto no existe', async () => {
+        const response = await auth(
+            request(app).delete(`/api/products/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).delete('/api/products/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -443,6 +443,20 @@ describe('GET /api/products/:warehouse_id/stocks — stock por warehouse', () =>
         expect(response.body.error.code).toBe('AppError');
     });
 
+    it('devuelve 400 (no 500) cuando el producto CONSUMABLE no tiene presentationQuantity', async () => {
+        const { company, yacht } = await createCompanyWithYacht(`StockCo-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const product = await createProductFixture({ type: 'CONSUMABLE', presentationQuantity: null });
+        await createStockFixture(product.id, warehouse.id, company.id);
+
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(warehouse.id)}/stocks`)
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
     it('devuelve 403 sin JWT', async () => {
         const response = await request(app).get('/api/products/any-id/stocks');
 
@@ -545,6 +559,32 @@ describe('PUT /api/products/upadate/stock/:stock_id — actualizar stock', () =>
             request(app)
                 .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
                 .send({ quantity: 15, userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 (no 500) cuando el producto CONSUMABLE no tiene presentationQuantity', async () => {
+        const { stock, staff } = await buildStockScenario({ type: 'CONSUMABLE', presentationQuantity: null });
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 15, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta userId (userId es obligatorio en toda actualización de stock)', async () => {
+        const { stock } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 15, responsable: 'Tester' })
         );
 
         expect(response.status).toBe(400);

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -214,3 +214,51 @@ describe('GET /api/products/allProductsWithConfigurations', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// POST /api/products/createProduct
+// =========================================================================
+
+describe('POST /api/products/createProduct — crear producto', () => {
+    it('devuelve 200 al crear un producto', async () => {
+        const s = suffix();
+        const response = await auth(
+            request(app)
+                .post('/api/products/createProduct')
+                .send({ name: `Nuevo-${s}`, sku: `NEW-${s}`, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource created successfully');
+    });
+
+    it('devuelve 400 cuando falta sku', async () => {
+        const response = await auth(
+            request(app)
+                .post('/api/products/createProduct')
+                .send({ name: `SinSku-${suffix()}`, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando el sku ya existe', async () => {
+        const existing = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .post('/api/products/createProduct')
+                .send({ name: `Dup-${suffix()}`, sku: existing.sku, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).post('/api/products/createProduct').send({});
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -190,3 +190,27 @@ describe('GET /api/products/findProduct/:sku — buscar por SKU', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// GET /api/products/allProductsWithConfigurations
+// =========================================================================
+
+describe('GET /api/products/allProductsWithConfigurations', () => {
+    it('devuelve 200 con las configuraciones activas', async () => {
+        const product = await createProductFixture();
+        await createProductConfigFixture(product.id);
+
+        const response = await auth(
+            request(app).get('/api/products/allProductsWithConfigurations')
+        );
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/allProductsWithConfigurations');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -262,3 +262,75 @@ describe('POST /api/products/createProduct — crear producto', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// PUT /api/products/updateProduct/:product_id
+// =========================================================================
+
+describe('PUT /api/products/updateProduct/:product_id — actualizar producto', () => {
+    it('devuelve 200 al actualizar el producto', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(product.id)}`)
+                .send({ name: 'Actualizado', sku: product.sku, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource updated successfully');
+    });
+
+    it('devuelve 200 al reenviar los mismos valores (update idempotente)', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(product.id)}`)
+                .send({ name: product.name, sku: product.sku, type: 'DISCRETE', unit: 'unidad' })
+        );
+
+        expect(response.status).toBe(200);
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app)
+                .put('/api/products/updateProduct/not-a-hashid')
+                .send({ name: 'X', sku: 'X', type: 'DISCRETE' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta sku', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(product.id)}`)
+                .send({ name: 'X', type: 'DISCRETE' })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el producto no existe', async () => {
+        const response = await auth(
+            request(app)
+                .put(`/api/products/updateProduct/${Utils.encode(999999)}`)
+                .send({ name: 'X', sku: `X-${suffix()}`, type: 'DISCRETE' })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).put('/api/products/updateProduct/any-id').send({});
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -449,3 +449,111 @@ describe('GET /api/products/:warehouse_id/stocks — stock por warehouse', () =>
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// PUT /api/products/upadate/stock/:stock_id
+// =========================================================================
+
+describe('PUT /api/products/upadate/stock/:stock_id — actualizar stock', () => {
+    async function buildStockScenario(productOverrides = {}) {
+        const { company, yacht } = await createCompanyWithYacht(`StockUpCo-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const product = await createProductFixture(productOverrides);
+        const staff = await createStaffFixture();
+        const stock = await createStockFixture(product.id, warehouse.id, company.id);
+        return { company, yacht, warehouse, product, staff, stock };
+    }
+
+    it('devuelve 200 y crea una Transaction al aumentar la cantidad', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 15, min: stock.min, max: stock.max, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(200);
+
+        const transactions = await Transaction.findAll({ where: { productId: stock.productId } });
+        expect(transactions).toHaveLength(1);
+        expect(transactions[0].type).toBe('IN');
+    });
+
+    it('devuelve 400 con hashid inválido en stock_id', async () => {
+        const { staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put('/api/products/upadate/stock/not-a-hashid')
+                .send({ quantity: 15, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el stock no existe', async () => {
+        const { staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(999999)}`)
+                .send({ quantity: 15, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta quantity, sin corromper el stock existente', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ min: 9, responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+
+        const refreshed = await Stock.findByPk(stock.id);
+        expect(Number(refreshed.quantity)).toBe(Number(stock.quantity));
+
+        const transactions = await Transaction.findAll({ where: { productId: stock.productId } });
+        expect(transactions).toHaveLength(0);
+    });
+
+    it('devuelve 400 cuando quantity no es numérico', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 'abc', responsable: 'Tester', userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 400 cuando falta responsable', async () => {
+        const { stock, staff } = await buildStockScenario();
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/upadate/stock/${Utils.encode(stock.id)}`)
+                .send({ quantity: 15, userId: Utils.encode(staff.id) })
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).put('/api/products/upadate/stock/any-id').send({});
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -412,3 +412,40 @@ describe('PUT /api/products/configurations/switchConfiguration/:configuration_id
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// GET /api/products/:warehouse_id/stocks
+// =========================================================================
+
+describe('GET /api/products/:warehouse_id/stocks — stock por warehouse', () => {
+    it('devuelve 200 con el stock del warehouse', async () => {
+        const { company, yacht } = await createCompanyWithYacht(`StockCo-${suffix()}`);
+        const warehouse = await createWarehouseFixture(yacht.id);
+        const product = await createProductFixture();
+        await createStockFixture(product.id, warehouse.id, company.id);
+
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(warehouse.id)}/stocks`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].product.sku).toBe(product.sku);
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).get('/api/products/not-a-hashid/stocks')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/any-id/stocks');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -158,3 +158,35 @@ describe('GET /api/products/:product_id — producto por ID', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// GET /api/products/findProduct/:sku
+// =========================================================================
+
+describe('GET /api/products/findProduct/:sku — buscar por SKU', () => {
+    it('devuelve 200 con el producto encontrado', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app).get(`/api/products/findProduct/${product.sku}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.sku).toBe(product.sku);
+    });
+
+    it('devuelve 404 cuando el sku no existe', async () => {
+        const response = await auth(
+            request(app).get(`/api/products/findProduct/NOPE-${suffix()}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/findProduct/any-sku');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -1,0 +1,160 @@
+const request = require('supertest');
+const { bootTestApp, shutdownTestApp } = require('../../helpers/testApp');
+const { createAuthenticatedUser } = require('../../helpers/auth');
+const { createDepartment, createPosition, createCompanyWithYacht } = require('../../helpers/staffFixtures');
+const Staff = require('../../../src/models/catalogs/staff.models');
+const Warehouse = require('../../../src/models/catalogs/wareHouse.models');
+const Product = require('../../../src/models/operations/inventory/product.models');
+const ProductConfiguration = require('../../../src/models/operations/inventory/productConfiguration');
+const Stock = require('../../../src/models/operations/inventory/stock.models');
+const Transaction = require('../../../src/models/operations/inventory/transaction.models');
+const Utils = require('../../../src/utils/Utils');
+
+let app;
+let token;
+let fixtureCounter = 0;
+
+const auth = (httpRequest) => httpRequest.set('Authorization', `Bearer ${token}`);
+const suffix = () => {
+    fixtureCounter += 1;
+    return `${Date.now()}-${fixtureCounter}`;
+};
+
+beforeAll(async () => {
+    app = await bootTestApp();
+    token = await createAuthenticatedUser(app);
+}, 60000);
+
+afterAll(async () => {
+    await shutdownTestApp();
+});
+
+// --- Helpers de fixtures --------------------------------------------------
+
+async function createStaffFixture() {
+    const dept = await createDepartment(`Dept-${suffix()}`);
+    const pos = await createPosition(`Pos-${suffix()}`);
+    const s = suffix();
+    return Staff.create({
+        firstName: 'TEST',
+        lastName: `Product${s}`,
+        email: `product-test-${s}@example.com`,
+        cellPhone: '0966666666',
+        password: 'Sup3rSecret!',
+        departamentId: dept.id,
+        positionId: pos.id,
+        contractType: 'Fijo',
+        active: true,
+    });
+}
+
+async function createWarehouseFixture(yachtId, overrides = {}) {
+    return Warehouse.create({
+        name: `Warehouse-${suffix()}`,
+        location: 'Bodega Test',
+        type: 'Yate',
+        yachtId,
+        ...overrides,
+    });
+}
+
+async function createProductFixture(overrides = {}) {
+    const s = suffix();
+    return Product.create({
+        name: `Producto-${s}`,
+        sku: `SKU-${s}`,
+        type: 'DISCRETE',
+        unit: 'unidad',
+        active: true,
+        ...overrides,
+    });
+}
+
+async function createProductConfigFixture(productId, overrides = {}) {
+    return ProductConfiguration.create({
+        name: `Config-${suffix()}`,
+        group: 'default',
+        productId,
+        sixteenPax: '1',
+        eighteenPax: '1',
+        twentyPax: '1',
+        twentyTwoPax: '1',
+        twentyFourPax: '1',
+        active: true,
+        ...overrides,
+    });
+}
+
+async function createStockFixture(productId, warehouseId, companyId, overrides = {}) {
+    return Stock.create({
+        productId,
+        warehouseId,
+        companyId,
+        quantity: 10,
+        max: 20,
+        min: 2,
+        ...overrides,
+    });
+}
+
+// =========================================================================
+// GET /api/products
+// =========================================================================
+
+describe('GET /api/products — lista de productos', () => {
+    it('devuelve 200 con la lista de productos', async () => {
+        await createProductFixture();
+
+        const response = await auth(request(app).get('/api/products'));
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products');
+
+        expect(response.status).toBe(403);
+    });
+});
+
+// =========================================================================
+// GET /api/products/:product_id
+// =========================================================================
+
+describe('GET /api/products/:product_id — producto por ID', () => {
+    it('devuelve 200 con el id codificado como hashid', async () => {
+        const product = await createProductFixture();
+
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(product.id)}`)
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBe(Utils.encode(product.id));
+    });
+
+    it('devuelve 400 con hashid inválido', async () => {
+        const response = await auth(
+            request(app).get('/api/products/not-a-hashid')
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 404 cuando el producto no existe', async () => {
+        const response = await auth(
+            request(app).get(`/api/products/${Utils.encode(999999)}`)
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app).get('/api/products/any-id');
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/tests/domain/operations-inventory-products/products.test.js
+++ b/tests/domain/operations-inventory-products/products.test.js
@@ -373,3 +373,42 @@ describe('DELETE /api/products/:product_id — eliminar producto', () => {
         expect(response.status).toBe(403);
     });
 });
+
+// =========================================================================
+// PUT /api/products/configurations/switchConfiguration/:configuration_id
+// =========================================================================
+
+describe('PUT /api/products/configurations/switchConfiguration/:configuration_id', () => {
+    it('devuelve 200 al actualizar la configuración', async () => {
+        const product = await createProductFixture();
+        const config = await createProductConfigFixture(product.id);
+
+        const response = await auth(
+            request(app)
+                .put(`/api/products/configurations/switchConfiguration/${config.id}`)
+                .send({ active: false })
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toBe('resource updated successfully');
+    });
+
+    it('devuelve 404 cuando la configuración no existe', async () => {
+        const response = await auth(
+            request(app)
+                .put('/api/products/configurations/switchConfiguration/999999')
+                .send({ active: false })
+        );
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.code).toBe('AppError');
+    });
+
+    it('devuelve 403 sin JWT', async () => {
+        const response = await request(app)
+            .put('/api/products/configurations/switchConfiguration/1')
+            .send({});
+
+        expect(response.status).toBe(403);
+    });
+});


### PR DESCRIPTION
## Resumen

Retrofitea los diez endpoints del dominio `inventory/products` (`/api/products`) al patrón `AppError`/`next(error)` (mismo estándar ya aplicado en `orders`, `downloads`, `yachtRequest`, etc.), corrige un bug de PK-encoding recurrente y cuatro endpoints que respondían 200 sobre un id inexistente, y cubre el dominio con 41 tests de integración contra DB real.

**Cambios en el controller (`src/controllers/operations/inventory/products.controller.js`):**
- Añade helper local `decodeId` (hashid inválido → `AppError(400)`), aplicado a `product_id`, `warehouse_id`, `stock_id` y `data.userId`
- Los diez handlers reemplazan `res.status(400).json(error.message)` por `next(error)`
- `getProduct`: fix de PK-encoding no-op (`result.dataValues.id = Utils.encode(...)` en vez de `result.id = ...`, que era un no-op silencioso) + 404 explícito cuando el producto no existe
- `findProduct`: 404 en vez de 400 cuando el sku no existe
- `createProduct`/`updateProduct`: `sku` ausente → `AppError(400)` explícito en vez de `TypeError` accidental por `.replace()` sobre `undefined`
- `deleteProduct`: 404 explícito cuando el producto no existe (antes: 200 con `data: undefined`)

**Cambios en el servicio (`src/services/operations/inventory/products.services.js`):**
- `createProduct`: SKU duplicado → `AppError(400)` en vez de `Error` genérico
- `updateProduct`, `switchConfirguration`: 404 vía patrón "buscar primero" (`findByPk` antes del `update`) — **no** vía `affectedRows === 0`, verificado empíricamente que MySQL sin `CLIENT_FOUND_ROWS` reporta `affectedRows: 0` tanto para un id inexistente como para un update idempotente (valores enviados idénticos), lo que produciría falsos 404
- `switchConfirguration`: cambia de firma `(data, options)` a `(data, configurationId)` para poder hacer el chequeo de existencia
- `deleteProduct`: 404 explícito cuando `Product.destroy` no afecta ninguna fila
- `getProductsByWarehouse`: el `warehouseId` decodificado y validado nunca llega `undefined` al SQL crudo (`Sequelize.literal`) de las subconsultas de transacciones
- `updateStock`: valida explícitamente `quantity` (número finito) y `responsable` (no vacío) antes de tocar la DB — antes, un payload inválido revienta con un error crudo de Sequelize/MySQL que el catch-all reportaba como 400 por accidente; sin esta validación, migrar a `next(error)` lo hubiera convertido en 500. `Stock` no encontrado → `AppError(404)` en vez de `Error` genérico
- `src/utils/quantity.js`: fix post-revisión-final — un producto CONSUMABLE sin `presentationQuantity` lanzaba `Error` genérico (500 tras el retrofit) en vez de `AppError(400)`; alcanzable desde `updateStock` y `getProductsByWarehouse`

**Tests:** 41 tests de integración en `tests/domain/operations-inventory-products/products.test.js` — suite completa (311/311) en verde.

## Proceso

Implementado con `superpowers:subagent-driven-development` — spec en `docs/superpowers/specs/2026-08-20-fase-2-inventory-products-design.md`, plan en `docs/superpowers/plans/2026-08-20-fase-2-inventory-products-plan.md`, un subagente implementador + revisor por task, y una revisión final de rama completa (modelo más capaz) antes de este PR.

**Decisiones registradas durante la implementación:**
- El hallazgo original del spec sobre `updateStock` describía una corrupción silenciosa (`Stock.quantity = NaN` persistido). Se verificó empíricamente contra la DB real que la transacción de Sequelize revierte por completo en ambos casos inválidos — no hay corrupción. El hallazgo se corrigió a lo que sí se comprobó: una regresión de clasificación de errores (400 accidental hoy → 500 tras el retrofit sin validación explícita).
- Se descartó el patrón `affectedRows === 0 → 404` (usado en `yachtRequest.updateRequest`, ya mergeado) para `updateProduct`/`switchConfirguration`, tras verificar empíricamente que produce falsos 404 en updates idempotentes. Se documentó como riesgo latente en `yachtRequest` para un fix futuro, fuera de alcance de este PR.
- La revisión final encontró 3 hallazgos Important reales: (1) `quantity.js` con `Error` genérico → 500 (corregido en este mismo branch), (2) `updateStock`'s `userId` se volvió obligatorio siempre como efecto secundario del retrofit — se mantuvo la restricción (mejor trazabilidad) y se documentó/testeó, (3) borrar un producto con stock/transacciones asociadas da 500 en vez de 409 — se dejó como seguimiento nombrado en el spec (`Hallazgos fuera de alcance`), no bloqueante.
- La falla intermitente de `tests/domain/auth-staff-users/users.test.js` en corridas de la suite completa se investigó y confirmó como flakiness preexistente no relacionada (cero archivos compartidos con este dominio, comportamiento inconsistente entre corridas, pasa limpio en la corrida final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)