### PR TITLE
feat: desempeno personas/preguntas increment (area filter, kpis, porFuncionMes)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-surveys-desempeno-dashboard-personas-preguntas-increment.md
+++ b/docs/superpowers/plans/2026-08-31-surveys-desempeno-dashboard-personas-preguntas-increment.md
@@ -1,0 +1,641 @@
+# Dashboard de Desempeño — Incremento Personas/Preguntas (Backend) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `GET /reports/desempeno/personas` and `GET /reports/desempeno/preguntas` (already merged in PR #17 with the old contract) up to the pbix-grounded contract in the spec: add the `area` filter to `/personas` plus the `kpisByYear`/`kpis` (with `calificacionMax`/`calificacionMin`)/`avgByYate`/`monthlyCalificacion`/`monthlyCompliance`/`monthlyCalificacionByYate` fields it's missing, and add `year` (on `porMes` rows) plus `porFuncionMes` to `/preguntas`.
+
+**Architecture:** Both endpoints already share `desempenoDashboard.services.js`'s helpers (`loadEvaluations`, `matchesYate`, `scoreValue`, `complianceValue`, `monthlySeriesByYear`, `buildCargoMap`, `groupRowsBy`) — this increment reuses them exactly as `getOverview`/`getYates` already do, plus adds one new lookup (`buildAreaMap`, mirroring `buildCargoMap` but resolving `Staff.staff_departament.name` instead of `Staff.staff_position.name`) to back the new `area` filter. No new tables; everything stays computed at request time.
+
+**Tech Stack:** Node.js, Express 4, Sequelize (MySQL), Jest + Supertest (domain tests boot the real app via `tests/helpers/testApp.js`).
+
+**Spec:** `docs/superpowers/specs/2026-08-31-surveys-desempeno-dashboard-design.md` (§3.3, §3.4, §8)
+
+## Global Constraints
+
+- **No dynamic object keys anywhere in a response.** Time series stay `{ categories: string[], series: [{ name: string, data: (number|null)[] }] }`. Tabular breakdowns stay arrays of `{ etiqueta, valor }` or equivalent explicit-key objects.
+- All computed averages/scores are `number | null` (`null` = no data, never `0`). All percentages are `0-100` integers.
+- **`area` filter convention (spec §8, open question resolved here):** the Excel's "Área" column has no direct model field. This repo already has a `Departaments`/`staff_departament` association on `Staff` (used nowhere yet for filtering) that is structurally identical to the `Positions`/`staff_position` association `funcion` already filters on. `area` filters by `Staff.staff_departament.name`, resolved the same way `funcion` resolves `Staff.staff_position.name` — via first/last name extracted from the evaluado's free-text name (`extractNombres`/`extractApellido`, `src/utils/reportFormatting.js`).
+- **`kpis.calificacionMax`/`calificacionMin` (spec §8):** max/min of the per-evaluation `calificacion` (`evaluationScore(row)`) among the rows matching the current filter — not a per-person or per-year aggregate, and not unfiltered.
+- **`porFuncionMes` groups by the evaluado's función (cargo)**, resolved via the same `buildCargoMap` `/personas` already uses — rows whose evaluado has no resolvable cargo are dropped from this breakdown (same drop-null-key behavior `groupRowsBy` already has everywhere else in this file).
+- Follow existing patterns exactly: controllers use `try { ... } catch (error) { next(error); }`; `@openapi` JSDoc blocks stay in sync with query params on every route in `reports.routes.js`; domain tests boot the real app via `tests/helpers/testApp.js`, fixture dates via `tests/helpers/dateFixtures.js`'s `setUpdatedAt(tableName, id, isoDateTime)` (always `T12:00:00`, never a bare date — see the original plan `2026-08-31-surveys-desempeno-dashboard-backend.md` for why).
+- **`Yacht`/company/staff fixture names must not contain all-caps acronyms.** `capitalizeYachtName` (`src/utils/reportFormatting.js`) lowercases everything but the first letter of each word (Roman numerals excepted), so a fixture yacht named `"... KPI ..."` comes back as `"... Kpi ..."` from `getYates`/`getPersonas` and breaks exact-string assertions. Use plain Title Case words in test fixture names (e.g. `"Personas Kpi Yacht"`, not `"Personas KPI Yacht"`).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/services/catalogs/staff.services.js` | Modified: add `Staffervice.getDepartmentsByFullNames(namePairs)`, mirroring the existing `getPositionsByFullNames` (lines 67-90) but resolving `staff_departament.name`. |
+| `src/services/reports/desempenoDashboard.services.js` | Modified: add `buildAreaMap(rows)` helper; rewrite `getPersonas` to add the `area` filter and the new response fields; rewrite `getPreguntas` to add `year` on `porMes` and the new `porFuncionMes` field. |
+| `src/controllers/reports/desempenoDashboard.controller.js` | Modified: `getDesempenoPersonas` reads and forwards `area`. |
+| `src/routes/reports/reports.routes.js` | Modified: `/desempeno/personas`'s `@openapi` block documents the new `area` query param. |
+| `tests/domain/reports/desempeno/desempenoDashboard.personas.test.js` | Modified: add tests for the `area` filter and for `kpisByYear`/`kpis.calificacionMax`/`calificacionMin`/`avgByYate`/`monthlyCalificacionByYate`. |
+| `tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js` | Modified: add a test for `year` on `porMes` rows and for `porFuncionMes`. |
+| `tests/domain/reports/desempeno/desempenoDashboard.routes.test.js` | Modified: extend the personas/preguntas shape assertions to cover the new top-level fields. |
+
+---
+
+### Task 1: `Staffervice.getDepartmentsByFullNames` + `buildAreaMap`
+
+**Files:**
+- Modify: `src/services/catalogs/staff.services.js:90` (insert after `getPositionsByFullNames`, before `getStaffCompanies`)
+- Modify: `src/services/reports/desempenoDashboard.services.js:81-101` (insert `buildAreaMap` after `buildCargoMap`)
+
+**Interfaces:**
+- Consumes: `Staff` model (`departamentId` FK, `staff_departament` association — already registered, used by `getAll`/`getStaffById`), `Departaments` model (already imported in `staff.services.js` line 4 as `Departaments`), `Op` (already imported).
+- Produces: `Staffervice.getDepartmentsByFullNames(namePairs: Array<{firstName, lastName}>)` → `Promise<Map<string, string|null>>` keyed by `"${firstName} ${lastName}"` — same shape as `getPositionsByFullNames`. `buildAreaMap(rows)` → `Promise<Map<string, string|null>>` keyed by the evaluado's full name — same shape as `buildCargoMap`, consumed by Task 2's `getPersonas`.
+
+No dedicated unit test for either — both are thin, structurally identical to the already-untested `getPositionsByFullNames`/`buildCargoMap`, and are exercised end-to-end by Task 2's `area` filter domain test.
+
+- [ ] **Step 1: Add `getDepartmentsByFullNames` to `staff.services.js`**
+
+Insert immediately after the closing `}` of `getPositionsByFullNames` (currently `src/services/catalogs/staff.services.js:90`):
+
+```js
+    static async getDepartmentsByFullNames(namePairs) {
+        try {
+            if (!namePairs || namePairs.length === 0) return new Map();
+
+            const staff = await Staff.findAll({
+                where: {
+                    active: true,
+                    [Op.or]: namePairs.map(({ firstName, lastName }) => ({ firstName, lastName })),
+                },
+                attributes: ['id', 'firstName', 'lastName'],
+                include: [{
+                    model: Departaments,
+                    as: 'staff_departament',
+                    attributes: ['id', 'name'],
+                }],
+            });
+
+            return new Map(
+                staff.map(s => [`${s.firstName} ${s.lastName}`, s.staff_departament?.name || null])
+            );
+        } catch (error) {
+            throw error;
+        }
+    }
+```
+
+- [ ] **Step 2: Add `buildAreaMap` to `desempenoDashboard.services.js`**
+
+Insert immediately after the closing `}` of `buildCargoMap` (currently `src/services/reports/desempenoDashboard.services.js:101`), before `async function getOverview`:
+
+```js
+async function buildAreaMap(rows) {
+    const uniqueEvaluados = [...new Set(rows.map((r) => r.evaluated).filter(Boolean))];
+    const namePairs = uniqueEvaluados
+        .map((evaluado) => ({
+            fullName: evaluado,
+            firstName: extractNombres(evaluado),
+            lastName: extractApellido(evaluado),
+        }))
+        .filter(({ firstName, lastName }) => firstName && lastName);
+
+    const areaByFullName = await Staffervice.getDepartmentsByFullNames(
+        namePairs.map(({ firstName, lastName }) => ({ firstName, lastName }))
+    );
+
+    return new Map(
+        namePairs.map(({ fullName, firstName, lastName }) => [
+            fullName,
+            areaByFullName.get(`${firstName} ${lastName}`) || null,
+        ])
+    );
+}
+```
+
+- [ ] **Step 3: Verify the app still builds**
+
+Run: `node -e "require('./src/services/reports/desempenoDashboard.services.js')"`
+Expected: no output, exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/catalogs/staff.services.js src/services/reports/desempenoDashboard.services.js
+git commit -m "feat: add area (departamento) lookup for the desempeno dashboard"
+```
+
+---
+
+### Task 2: `getPersonas` — `area` filter + `kpisByYear`/`kpis`/`avgByYate`/monthly series
+
+**Files:**
+- Modify: `src/services/reports/desempenoDashboard.services.js:179-239` (replace the whole `getPersonas` function)
+- Test: `tests/domain/reports/desempeno/desempenoDashboard.personas.test.js`
+
+**Interfaces:**
+- Consumes (from Task 1 and the existing file): `loadEvaluations`, `buildCargoMap`, `buildAreaMap`, `matchesYate`, `evaluationDate`, `evaluationScore`, `yateName`, `MESES`, `scoreValue`, `complianceValue`, `compliancePercent`, `quarterOf`, `monthlySeriesByYear`, `round2`, `groupRowsBy`.
+- Produces: `getPersonas({ yate, evaluado, funcion, area, anio } = {})` → `Promise<{ kpisByYear: Array<{year, calificacion, compliancePercent, completadas, caducadas}>, kpis: {calificacion, calificacionMax, calificacionMin, compliancePercent, completadas, caducadas}, avgByYate: Array<{yate, calificacion}>, monthlyCalificacion: {categories, series}, monthlyCompliance: {categories, series}, monthlyCalificacionByYate: Array<{yate, categories, series}>, months: Array<{month, monthIndex}>, porEvaluado: Array<{evaluado, porMes, total}>, porEvaluadorMensual: Array<{evaluador, porMes, total}>, porEvaluadorTrimestre: Array<{evaluador, porTrimestre, total}>, comentarios: Array<{evaluado, evaluador, texto}> }>`. `porEvaluado`/`porEvaluadorMensual`/`porEvaluadorTrimestre`/`comentarios`/`months` keep their exact prior shape (unchanged fields per spec §3.3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the `const { getPersonas } = require(...)` import line and add two new `it` blocks inside the existing `describe('desempenoDashboard.services getPersonas', ...)` block in `tests/domain/reports/desempeno/desempenoDashboard.personas.test.js` — first widen the imports at the top of the file:
+
+```js
+const { bootTestApp, shutdownTestApp } = require('../../../helpers/testApp');
+const { createCompanyWithYacht, createDepartment, createPosition } = require('../../../helpers/staffFixtures');
+const { setUpdatedAt } = require('../../../helpers/dateFixtures');
+const Form = require('../../../../src/models/operations/surveys/form.models');
+const FormQuestion = require('../../../../src/models/operations/surveys/formQuestion.models');
+const FormRespond = require('../../../../src/models/operations/surveys/formRespond.models');
+const FormAnswers = require('../../../../src/models/operations/surveys/formAnswers.models');
+const Staff = require('../../../../src/models/catalogs/staff.models');
+const { getPersonas } = require('../../../../src/services/reports/desempenoDashboard.services');
+```
+
+Then add these two `it` blocks right after the existing one (before the closing `});` of the `describe`):
+
+```js
+    it('returns kpisByYear, kpis with max/min, and per-yate breakdowns scoped to the current filter', async () => {
+        const caseSuffix = `${Date.now()}`;
+        const yachtName = `Personas Kpi Yacht ${caseSuffix}`;
+        const { company } = await createCompanyWithYacht(`Personas Kpi Co ${caseSuffix}`, yachtName);
+        const form = await Form.create({ name: `Form Personas Kpi ${caseSuffix}`, positions: [] });
+        const question = await FormQuestion.create({ formId: form.id, title: 'Pregunta 1', type: 'scale' });
+
+        const high = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador Kpi ${caseSuffix}`, evaluated: `Evaluado Kpi Alto ${caseSuffix}`,
+            expirationDate: new Date('2025-08-01'),
+        });
+        await setUpdatedAt('form_responds', high.id, '2025-08-05T12:00:00');
+        await FormAnswers.create({ respuestaId: high.id, questionId: question.id, answer: '5' });
+
+        const low = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador Kpi ${caseSuffix}`, evaluated: `Evaluado Kpi Bajo ${caseSuffix}`,
+            expirationDate: new Date('2025-08-01'),
+        });
+        await setUpdatedAt('form_responds', low.id, '2025-08-10T12:00:00');
+        await FormAnswers.create({ respuestaId: low.id, questionId: question.id, answer: '2' });
+
+        const result = await getPersonas({ yate: yachtName, anio: 2025 });
+        const year2025 = result.kpisByYear.find((k) => k.year === 2025);
+
+        expect(year2025.calificacion).toBe(3.5);
+        expect(result.kpis.calificacionMax).toBe(5);
+        expect(result.kpis.calificacionMin).toBe(2);
+        expect(result.avgByYate.find((y) => y.yate === yachtName).calificacion).toBe(3.5);
+        expect(result.monthlyCalificacionByYate.find((y) => y.yate === yachtName)).toBeDefined();
+    });
+
+    it('filters by area (departamento) resolved from the evaluado staff record', async () => {
+        const caseSuffix = `${Date.now()}`;
+        const { company } = await createCompanyWithYacht(`Personas Area Co ${caseSuffix}`);
+        const department = await createDepartment(`Cubierta ${caseSuffix}`);
+        const position = await createPosition(`Marinero ${caseSuffix}`);
+        const firstName = `AreaFN${caseSuffix}`;
+        const lastName = 'Perez Lopez';
+        await Staff.create({
+            firstName,
+            lastName,
+            email: `area-test-${caseSuffix}@example.com`,
+            cellPhone: '0966666666',
+            password: 'Sup3rSecret!',
+            departamentId: department.id,
+            positionId: position.id,
+            contractType: 'Fijo',
+            active: true,
+        });
+        const evaluatedFullName = `${firstName} ${lastName}`;
+
+        const form = await Form.create({ name: `Form Personas Area ${caseSuffix}`, positions: [] });
+        const question = await FormQuestion.create({ formId: form.id, title: 'Pregunta 1', type: 'scale' });
+        const respond = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador Area ${caseSuffix}`, evaluated: evaluatedFullName,
+            expirationDate: new Date('2025-07-01'),
+        });
+        await setUpdatedAt('form_responds', respond.id, '2025-07-05T12:00:00');
+        await FormAnswers.create({ respuestaId: respond.id, questionId: question.id, answer: '5' });
+
+        const matched = await getPersonas({ area: department.name, anio: 2025 });
+        const unmatched = await getPersonas({ area: 'Area Que No Existe', anio: 2025 });
+
+        expect(matched.porEvaluado.some((p) => p.evaluado === evaluatedFullName)).toBe(true);
+        expect(unmatched.porEvaluado.some((p) => p.evaluado === evaluatedFullName)).toBe(false);
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest tests/domain/reports/desempeno/desempenoDashboard.personas.test.js`
+Expected: FAIL — `result.kpisByYear` / `result.kpis.calificacionMax` / `result.avgByYate` are `undefined`, and the `area` filter is silently ignored (both `matched`/`unmatched` contain the row).
+
+- [ ] **Step 3: Replace `getPersonas`**
+
+Replace the whole current function (`src/services/reports/desempenoDashboard.services.js:179-239`, from `async function getPersonas({ yate, evaluado, funcion, anio } = {}) {` through its closing `}`):
+
+```js
+async function getPersonas({ yate, evaluado, funcion, area, anio } = {}) {
+    const allRows = await loadEvaluations();
+    const cargoMap = funcion ? await buildCargoMap(allRows) : new Map();
+    const areaMap = area ? await buildAreaMap(allRows) : new Map();
+
+    const rows = allRows.filter((row) => {
+        if (!matchesYate(row, yate)) return false;
+        if (evaluado && row.evaluated?.trim().toLowerCase() !== evaluado.trim().toLowerCase()) return false;
+        if (funcion && (cargoMap.get(row.evaluated) || '').toLowerCase() !== funcion.trim().toLowerCase()) return false;
+        if (area && (areaMap.get(row.evaluated) || '').toLowerCase() !== area.trim().toLowerCase()) return false;
+        if (anio && evaluationDate(row).getFullYear() !== Number(anio)) return false;
+        return true;
+    });
+
+    const years = [...new Set(rows.map((row) => evaluationDate(row).getFullYear()))].sort((a, b) => a - b);
+    const kpisByYear = years.map((year) => {
+        const yearRows = rows.filter((row) => evaluationDate(row).getFullYear() === year);
+        const completadas = yearRows.filter((row) => row.state === 'Completada').length;
+        const caducadas = yearRows.filter((row) => row.state === 'Caducada').length;
+        return {
+            year,
+            calificacion: scoreValue(yearRows),
+            compliancePercent: compliancePercent(completadas, caducadas),
+            completadas,
+            caducadas,
+        };
+    });
+
+    const completadas = rows.filter((row) => row.state === 'Completada').length;
+    const caducadas = rows.filter((row) => row.state === 'Caducada').length;
+    const scoresPerRow = rows.map(evaluationScore).filter((s) => s !== null);
+
+    const yateGroups = new Map();
+    rows.forEach((row) => {
+        const rowYate = yateName(row);
+        if (!rowYate) return;
+        if (!yateGroups.has(rowYate)) yateGroups.set(rowYate, []);
+        yateGroups.get(rowYate).push(row);
+    });
+    const avgByYate = [...yateGroups.entries()]
+        .map(([rowYate, yateRows]) => ({ yate: rowYate, calificacion: scoreValue(yateRows) }))
+        .sort((a, b) => a.yate.localeCompare(b.yate));
+    const monthlyCalificacionByYate = [...yateGroups.entries()]
+        .map(([rowYate, yateRows]) => ({
+            yate: rowYate,
+            ...monthlySeriesByYear(yateRows, scoreValue),
+        }))
+        .sort((a, b) => a.yate.localeCompare(b.yate));
+
+    const monthIndexesPresent = [...new Set(rows.map((row) => evaluationDate(row).getMonth()))].sort((a, b) => a - b);
+    const months = monthIndexesPresent.map((monthIndex) => ({ month: MESES[monthIndex], monthIndex: monthIndex + 1 }));
+
+    const porEvaluado = [...groupRowsBy(rows, (row) => row.evaluated).entries()]
+        .map(([evaluadoName, personRows]) => ({
+            evaluado: evaluadoName,
+            porMes: months.map(({ month, monthIndex }) => ({
+                month,
+                monthIndex,
+                valor: scoreValue(personRows.filter((row) => evaluationDate(row).getMonth() === monthIndex - 1)),
+            })),
+            total: scoreValue(personRows),
+        }))
+        .sort((a, b) => a.evaluado.localeCompare(b.evaluado));
+
+    const porEvaluadorMensual = [...groupRowsBy(rows, (row) => row.evaluator).entries()]
+        .map(([evaluador, evaluatorRows]) => ({
+            evaluador,
+            porMes: months.map(({ month, monthIndex }) => ({
+                month,
+                monthIndex,
+                valor: complianceValue(evaluatorRows.filter((row) => evaluationDate(row).getMonth() === monthIndex - 1)),
+            })),
+            total: complianceValue(evaluatorRows),
+        }))
+        .sort((a, b) => a.evaluador.localeCompare(b.evaluador));
+
+    const porEvaluadorTrimestre = [...groupRowsBy(rows, (row) => row.evaluator).entries()]
+        .map(([evaluador, evaluatorRows]) => {
+            const trimestres = [...new Set(evaluatorRows.map((row) => quarterOf(evaluationDate(row))))].sort();
+            return {
+                evaluador,
+                porTrimestre: trimestres.map((trimestre) => ({
+                    trimestre,
+                    valor: scoreValue(evaluatorRows.filter((row) => quarterOf(evaluationDate(row)) === trimestre)),
+                })),
+                total: scoreValue(evaluatorRows),
+            };
+        })
+        .sort((a, b) => a.evaluador.localeCompare(b.evaluador));
+
+    const comentarios = rows.flatMap((row) =>
+        (row.respuestas || [])
+            .filter((r) => r.answer && typeof SurveyScoring.asignarPuntaje(r.answer) !== 'number')
+            .map((r) => ({ evaluado: row.evaluated, evaluador: row.evaluator, texto: r.answer }))
+    );
+
+    return {
+        kpisByYear,
+        kpis: {
+            calificacion: scoreValue(rows),
+            calificacionMax: scoresPerRow.length ? round2(Math.max(...scoresPerRow)) : null,
+            calificacionMin: scoresPerRow.length ? round2(Math.min(...scoresPerRow)) : null,
+            compliancePercent: compliancePercent(completadas, caducadas),
+            completadas,
+            caducadas,
+        },
+        avgByYate,
+        monthlyCalificacion: monthlySeriesByYear(rows, scoreValue),
+        monthlyCompliance: monthlySeriesByYear(rows, complianceValue),
+        monthlyCalificacionByYate,
+        months,
+        porEvaluado,
+        porEvaluadorMensual,
+        porEvaluadorTrimestre,
+        comentarios,
+    };
+}
+```
+
+`module.exports` already includes `getPersonas` by reference — no change needed there.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest tests/domain/reports/desempeno/desempenoDashboard.personas.test.js`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/reports/desempenoDashboard.services.js tests/domain/reports/desempeno/desempenoDashboard.personas.test.js
+git commit -m "feat: add area filter and kpis/avgByYate breakdowns to desempeno personas"
+```
+
+---
+
+### Task 3: `getPreguntas` — `year` on `porMes` + `porFuncionMes`
+
+**Files:**
+- Modify: `src/services/reports/desempenoDashboard.services.js:251-300` (replace the whole `getPreguntas` function)
+- Test: `tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js`
+
+**Interfaces:**
+- Consumes: `loadEvaluations`, `buildCargoMap`, `evaluationDate`, `MESES`, `scoreValue`, `groupRowsBy`, `scoreForCompetencia` (already defined just above `getPreguntas`, unchanged).
+- Produces: `getPreguntas({ evaluado, funcion, anio } = {})` → `Promise<{ competencias: string[], porMes: Array<{year, month, monthIndex, valores}>, porFuncionMes: Array<{funcion, porMes: Array<{year, month, monthIndex, valores}>}>, porEvaluador: Array<{evaluador, valores, calificacion}> }>`. `competencias` and `porEvaluador` keep their exact prior shape.
+- **Behavior change:** `cargoMap` is now always built (previously only when `funcion` was passed), because `porFuncionMes` needs every row's cargo regardless of whether `funcion` is used as a filter.
+
+- [ ] **Step 1: Write the failing test**
+
+Widen the imports at the top of `tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js`:
+
+```js
+const { bootTestApp, shutdownTestApp } = require('../../../helpers/testApp');
+const { createCompanyWithYacht, createDepartment, createPosition } = require('../../../helpers/staffFixtures');
+const { setUpdatedAt } = require('../../../helpers/dateFixtures');
+const Form = require('../../../../src/models/operations/surveys/form.models');
+const FormQuestion = require('../../../../src/models/operations/surveys/formQuestion.models');
+const FormRespond = require('../../../../src/models/operations/surveys/formRespond.models');
+const FormAnswers = require('../../../../src/models/operations/surveys/formAnswers.models');
+const Staff = require('../../../../src/models/catalogs/staff.models');
+const { getPreguntas } = require('../../../../src/services/reports/desempenoDashboard.services');
+```
+
+Add this `it` block right after the existing one (before the closing `});` of the `describe`):
+
+```js
+    it('includes year on porMes rows and breaks calificación down by función×mes via porFuncionMes', async () => {
+        const caseSuffix = `${Date.now()}`;
+        const { company } = await createCompanyWithYacht(`Preguntas FuncionMes Co ${caseSuffix}`);
+        const department = await createDepartment(`Cubierta ${caseSuffix}`);
+        const position = await createPosition(`Capitan ${caseSuffix}`);
+        const firstName = `PFM${caseSuffix}`;
+        const lastName = 'Rios Vera';
+        await Staff.create({
+            firstName,
+            lastName,
+            email: `pfm-test-${caseSuffix}@example.com`,
+            cellPhone: '0966666666',
+            password: 'Sup3rSecret!',
+            departamentId: department.id,
+            positionId: position.id,
+            contractType: 'Fijo',
+            active: true,
+        });
+        const evaluatedFullName = `${firstName} ${lastName}`;
+
+        const form = await Form.create({ name: `Form Preguntas FuncionMes ${caseSuffix}`, positions: [] });
+        const question = await FormQuestion.create({ formId: form.id, title: 'Liderazgo', type: 'scale' });
+        const respond = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador FuncionMes ${caseSuffix}`, evaluated: evaluatedFullName,
+            expirationDate: new Date('2025-09-01'),
+        });
+        await setUpdatedAt('form_responds', respond.id, '2025-09-10T12:00:00');
+        await FormAnswers.create({ respuestaId: respond.id, questionId: question.id, answer: '4' });
+
+        const result = await getPreguntas({ anio: 2025 });
+
+        const septiembreRow = result.porMes.find((m) => m.year === 2025 && m.monthIndex === 9);
+        expect(septiembreRow).toBeDefined();
+
+        const funcionRow = result.porFuncionMes.find((f) => f.funcion === position.name);
+        expect(funcionRow).toBeDefined();
+        const funcionSeptiembre = funcionRow.porMes.find((m) => m.year === 2025 && m.monthIndex === 9);
+        expect(funcionSeptiembre.valores.find((v) => v.etiqueta === 'Liderazgo').valor).toBe(4);
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js`
+Expected: FAIL — `m.year` is `undefined` on existing `porMes` rows and `result.porFuncionMes` is `undefined`.
+
+- [ ] **Step 3: Replace `getPreguntas`**
+
+Replace the whole current function (`src/services/reports/desempenoDashboard.services.js:251-300`, from `async function getPreguntas({ evaluado, funcion, anio } = {}) {` through its closing `}`):
+
+```js
+function porMesFor(rows, competencias) {
+    const yearMonthKeys = [...new Set(rows.map((row) => {
+        const date = evaluationDate(row);
+        return `${date.getFullYear()}-${date.getMonth()}`;
+    }))]
+        .map((key) => {
+            const [year, monthIndex] = key.split('-').map(Number);
+            return { year, monthIndex };
+        })
+        .sort((a, b) => (a.year - b.year) || (a.monthIndex - b.monthIndex));
+
+    return yearMonthKeys.map(({ year, monthIndex }) => {
+        const monthRows = rows.filter((row) => {
+            const date = evaluationDate(row);
+            return date.getFullYear() === year && date.getMonth() === monthIndex;
+        });
+        return {
+            year,
+            month: MESES[monthIndex],
+            monthIndex: monthIndex + 1,
+            valores: competencias.map((competencia) => ({
+                etiqueta: competencia,
+                valor: scoreForCompetencia(monthRows, competencia),
+            })),
+        };
+    });
+}
+
+async function getPreguntas({ evaluado, funcion, anio } = {}) {
+    const allRows = await loadEvaluations();
+    const cargoMap = await buildCargoMap(allRows);
+
+    const rows = allRows.filter((row) => {
+        if (evaluado && row.evaluated?.trim().toLowerCase() !== evaluado.trim().toLowerCase()) return false;
+        if (funcion && (cargoMap.get(row.evaluated) || '').toLowerCase() !== funcion.trim().toLowerCase()) return false;
+        if (anio && evaluationDate(row).getFullYear() !== Number(anio)) return false;
+        return true;
+    });
+
+    const competencias = [];
+    const seen = new Set();
+    rows.forEach((row) => {
+        (row.respuestas || []).forEach((r) => {
+            const title = r.pregunta?.title;
+            if (!title || seen.has(title)) return;
+            if (typeof SurveyScoring.asignarPuntaje(r.answer) === 'number') {
+                seen.add(title);
+                competencias.push(title);
+            }
+        });
+    });
+
+    const porMes = porMesFor(rows, competencias);
+
+    const porFuncionMes = [...groupRowsBy(rows, (row) => cargoMap.get(row.evaluated) || null).entries()]
+        .map(([funcionName, funcionRows]) => ({
+            funcion: funcionName,
+            porMes: porMesFor(funcionRows, competencias),
+        }))
+        .sort((a, b) => a.funcion.localeCompare(b.funcion));
+
+    const porEvaluador = [...groupRowsBy(rows, (row) => row.evaluator).entries()]
+        .map(([evaluador, evaluatorRows]) => ({
+            evaluador,
+            valores: competencias.map((competencia) => ({
+                etiqueta: competencia,
+                valor: scoreForCompetencia(evaluatorRows, competencia),
+            })),
+            calificacion: scoreValue(evaluatorRows),
+        }))
+        .sort((a, b) => a.evaluador.localeCompare(b.evaluador));
+
+    return { competencias, porMes, porFuncionMes, porEvaluador };
+}
+```
+
+`porMesFor` is module-internal (defined above `getPreguntas`, not exported) — it replaces the inline `monthIndexesPresent`/`porMes` computation the old function had, and is reused for the top-level `porMes` and for each entry of `porFuncionMes`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/reports/desempenoDashboard.services.js tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js
+git commit -m "feat: add year and porFuncionMes to desempeno preguntas"
+```
+
+---
+
+### Task 4: Controller, routes, and route-level shape tests
+
+**Files:**
+- Modify: `src/controllers/reports/desempenoDashboard.controller.js:29-42` (the `getDesempenoPersonas` handler)
+- Modify: `src/routes/reports/reports.routes.js:251-283` (the `/desempeno/personas` `@openapi` block)
+- Modify: `tests/domain/reports/desempeno/desempenoDashboard.routes.test.js`
+
+**Interfaces:**
+- Consumes: `getPersonas` (Task 2), `getPreguntas` (Task 3) — both already imported in the controller, no import changes needed.
+
+- [ ] **Step 1: Write the failing route-test assertions**
+
+In `tests/domain/reports/desempeno/desempenoDashboard.routes.test.js`, replace the two `it` blocks for personas and preguntas:
+
+```js
+    it('returns the personas shape, including the new yearly/per-yate breakdowns', async () => {
+        const response = await withAuth(request(app).get('/api/reports/desempeno/personas'), adminToken);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('porEvaluado');
+        expect(response.body).toHaveProperty('comentarios');
+        expect(response.body).toHaveProperty('kpisByYear');
+        expect(response.body).toHaveProperty('kpis');
+        expect(response.body).toHaveProperty('avgByYate');
+        expect(response.body).toHaveProperty('monthlyCalificacionByYate');
+    });
+
+    it('returns the preguntas shape, including porFuncionMes', async () => {
+        const response = await withAuth(request(app).get('/api/reports/desempeno/preguntas'), adminToken);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('competencias');
+        expect(response.body).toHaveProperty('porMes');
+        expect(response.body).toHaveProperty('porFuncionMes');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest tests/domain/reports/desempeno/desempenoDashboard.routes.test.js`
+Expected: FAIL — `response.body.kpisByYear`/`avgByYate`/`porFuncionMes` are `undefined` (controller doesn't forward `area` yet either, but that alone doesn't fail this shape assertion — Task 2/3's service change already makes these fields exist; this step should actually PASS already once Task 2/3 land. Run it anyway to confirm before touching the controller/routes.)
+
+- [ ] **Step 3: Add `area` to the controller**
+
+In `src/controllers/reports/desempenoDashboard.controller.js`, replace the `getDesempenoPersonas` handler:
+
+```js
+const getDesempenoPersonas = async (req, res, next) => {
+    try {
+        const { yate, evaluado, funcion, area, anio } = req.query;
+        const personas = await getPersonas({
+            yate: asString(yate),
+            evaluado: asString(evaluado),
+            funcion: asString(funcion),
+            area: asString(area),
+            anio: asString(anio),
+        });
+        res.status(200).json(personas);
+    } catch (error) {
+        next(error);
+    }
+};
+```
+
+- [ ] **Step 4: Document the `area` query param**
+
+In `src/routes/reports/reports.routes.js`, inside the `/desempeno/personas` `@openapi` block, add the `area` parameter right after `funcion` (between the existing `funcion` and `anio` parameter entries):
+
+```js
+ *       - in: query
+ *         name: area
+ *         schema:
+ *           type: string
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx jest tests/domain/reports/desempeno/desempenoDashboard.routes.test.js`
+Expected: PASS (6 tests)
+
+Run: `npx jest tests/domain/reports/desempeno`
+Expected: PASS (all 5 files)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/controllers/reports/desempenoDashboard.controller.js src/routes/reports/reports.routes.js tests/domain/reports/desempeno/desempenoDashboard.routes.test.js
+git commit -m "feat: wire area filter and document it on the desempeno personas route"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §3.3 `area` query param → Task 2 Step 3 + Task 4 Step 3-4. §3.3 `kpisByYear`/`kpis` (incl. `calificacionMax`/`calificacionMin`)/`avgByYate`/`monthlyCalificacion`/`monthlyCompliance`/`monthlyCalificacionByYate` → Task 2 Step 3. §3.3 unchanged fields (`months`, `porEvaluado`, `porEvaluadorMensual`, `porEvaluadorTrimestre`, `comentarios`) → preserved verbatim in Task 2 Step 3's rewrite. §3.4 `year` on `porMes` → Task 3 Step 3 (`porMesFor`). §3.4 `porFuncionMes` → Task 3 Step 3. §8 `area` convention (Departaments, not a new column) → Task 1 + Global Constraints. §8 `calificacionMax`/`calificacionMin` definition → Global Constraints + Task 2 Step 3 (`scoresPerRow`, per-evaluation not per-person).
+- **Placeholder scan:** no TBD/TODO; every step has runnable commands or complete code.
+- **Type consistency:** `getPersonas`'s new signature `{ yate, evaluado, funcion, area, anio }` matches the controller's Task 4 Step 3 destructure exactly. `buildAreaMap`/`getDepartmentsByFullNames` (Task 1) match their call sites in Task 2 Step 3 exactly (`area ? await buildAreaMap(allRows) : new Map()`). `porMesFor(rows, competencias)` (Task 3) is defined once and reused for both the top-level `porMes` and each `porFuncionMes` entry, never redefined. `groupRowsBy` (already exported from the file, used unchanged) is reused by name in Task 3 exactly as it already is in `getPersonas`/`getPreguntas`'s `porEvaluador`.
+- **Route/controller consistency:** the `area` param documented in Task 4 Step 4 matches the `req.query.area` read in Task 4 Step 3 and the `area` field `getPersonas` (Task 2) accepts.
+- **Test-fixture consistency:** every new domain test follows the established pattern (`bootTestApp`/`shutdownTestApp`, `setUpdatedAt` with a noon timestamp, a `caseSuffix` from `Date.now()` to avoid cross-test collisions) and avoids all-caps acronyms in yacht/company names per the Global Constraints note on `capitalizeYachtName`.

--- a/docs/superpowers/specs/2026-08-31-surveys-desempeno-dashboard-design.md
+++ b/docs/superpowers/specs/2026-08-31-surveys-desempeno-dashboard-design.md
@@ -10,15 +10,32 @@ Este documento reemplaza la necesidad de completar `docs/superpowers/specs/2026-
 
 ## Alcance de esta iteración
 
-**Dentro de alcance:**
-- Las 4 vistas del reporte de desempeño de tripulación: Overview, por Yate, por Persona (Evaluado/Evaluador), por Pregunta/Competencia.
+**Fuente de verdad, verificada directamente contra los archivos originales:**
+- **Diseño visual** (qué gráficos/tablas mostrar, por qué página): `reporte/Reporte Desempeño.pbix` (10 páginas). Este spec traduce el diseño de esas páginas a los 4 endpoints — no se inventan vistas nuevas ni se asume el patrón genérico de `ChartOne.jsx` por defecto.
+- **Data**: exclusivamente la hoja **"General Tripulación"** del Excel (`reporte/Reporte General Desempeño Embarcaciones.xlsx`), cuya tabla es `Report_General_Final` (columnas: Formulario, Evaluador, Evaluado, Función, Área, Yate, Año, Trimestre, Fecha Final, Estatus Evaluación, Pregunta 1-10, Puntuación, Estado...). Las demás hojas del libro (`Completo 2024`, `Comment_Cards`, `Comentarios_Agencias`, `REPORTE ANTIGUO - 2025`) NO alimentan ninguno de los 4 endpoints de este spec.
+
+**Dentro de alcance — mapeo página pbix → vista/endpoint:**
+
+| Página pbix | Vista/endpoint |
+|---|---|
+| Desempeño Barco - Año | `overview` (3.1) |
+| Barco - Capitán | `personas` (3.3), filtrada por `funcion` |
+| Liderazgo - Capitanes Ítems | `preguntas` (3.4) |
+| Desempeño Individual - Año | `personas` (3.3) |
+| Cumplimiento - Individual | `personas` (3.3) |
+| Desempeño individual 360 | `personas` (3.3) |
+
+(`yates`, 3.2, generaliza el patrón de la página "Desempeño Barco 2026" sin fijar el año — ver nota al final de 3.2.)
+
 - Diseño completo (backend + frontend) documentado en este spec.
 - **Implementación en esta sesión: solo el backend** (`interno-api`) — los 4 endpoints de agregación y la limpieza del código Power BI en este repo.
 - El diseño de frontend (componentes, contrato de datos que consumen) queda documentado aquí para una sesión posterior en `interno-react`.
 
-**Fuera de alcance (explícitamente, no ahora):**
-- Comment Cards de pasajeros (dominio ya existe en `comentCard.*`, pero no se toca en este plan).
-- Comment Cards y Reclamos de Agencias (no hay módulo de "reclamos de agencia" identificado en el backend — requeriría su propio spec).
+**Fuera de alcance (explícitamente, no ahora) — páginas del pbix que NO se replican:**
+- **"Desempeño Barco 2026"**: es la misma información de `yates` (3.2) pero con el filtro de año fijado a 2026 en el mockup; `yates` ya la generaliza sin asumir "año actual" (ver nota en 3.2), así que no se construye como vista separada.
+- **"Comment Cards 2026"** (hoja `Comment_Cards`): Comment Cards de pasajeros, dominio ya existe en `comentCard.*`, pero no se toca en este plan.
+- **"Reclamo Agencias 2026"** (hoja `Comentarios_Agencias`): no hay módulo de "reclamos de agencia" identificado en el backend — requeriría su propio spec, y su data no vive en "General Tripulación".
+- **"Bonos - Trimestre 2026"** (hoja `Completo 2024`, tabla `Report_Gen324`): datos de compensación (`Bono Puntuación`, `Monto`, `Observación`) cargados manualmente, no derivables de `FormRespond`/`FormAnswers` ni de "General Tripulación". Fuera de alcance por la misma razón que Reclamos de Agencias — requeriría su propio spec y su propia fuente de datos.
 - Implementación del frontend (`interno-react`) — queda para otra sesión, usando el diseño de la sección 5 como contrato.
 
 ## 1. Métricas — definiciones verificadas contra el Excel fuente
@@ -68,7 +85,7 @@ Query: `yate?` (id o nombre del yate; sin filtro = todos).
 ### 3.2 `GET /reports/desempeno/yates`
 Query: `yate?` (filtra `kpis`; `avgByYate` y `monthlyCalificacionByYate` siempre muestran los 4 yates).
 
-`monthlyCalificacion`/`monthlyCompliance` usan el **mismo shape multi-año que `overview`** (una serie por año, no una sola línea) — el mockup de Power BI mostraba una sola línea porque tenía el filtro de año fijo en la última pantalla capturada, pero el backend no asume "año actual"; el frontend decide qué año(s) graficar con la data completa.
+`monthlyCalificacion`/`monthlyCompliance` usan el **mismo shape multi-año que `overview`** (una serie por año, no una sola línea) — el mockup de Power BI mostraba una sola línea porque tenía el filtro de año fijo en la última pantalla capturada (página "Desempeño Barco 2026" del pbix), pero el backend no asume "año actual"; el frontend decide qué año(s) graficar con la data completa. Por esto no se replica "Desempeño Barco 2026" como vista separada (ver sección "Alcance") — este endpoint ya la generaliza.
 
 ```json
 {
@@ -83,10 +100,24 @@ Query: `yate?` (filtra `kpis`; `avgByYate` y `monthlyCalificacionByYate` siempre
 ```
 
 ### 3.3 `GET /reports/desempeno/personas`
-Query: `yate?`, `evaluado?`, `funcion?`, `anio?`.
+Query: `yate?`, `evaluado?`, `funcion?`, `area?`, `anio?`.
+
+Este endpoint cubre 4 páginas del pbix ("Barco - Capitán", "Desempeño Individual - Año", "Cumplimiento - Individual", "Desempeño individual 360"), todas con los mismos filtros base (Evaluado/Función/Área/Yate/Año vía slicers) mirando el mismo universo de datos desde ángulos distintos — por eso comparten un solo endpoint en vez de cuatro. `funcion=Capitán` reproduce el filtro fijo de la página "Barco - Capitán".
+
+`kpisByYear` y `kpis` reutilizan el shape de `overview`/`yates` (no se inventa un shape nuevo por vista): `kpisByYear` alimenta las cards por año de "Desempeño Individual - Año"; `kpis` (agregado sobre el filtro actual, sin desglose por año) alimenta las cards de "Barco - Capitán" y "Desempeño individual 360" — incluye `calificacionMax`/`calificacionMin`, que no existían en la versión anterior de este contrato. `avgByYate` y `monthlyCalificacionByYate` reusan el shape de `yates` (3.2) para la página "Barco - Capitán" (columnChart Puntuación×Yate, lineChart Calificación×Mes×Yate). `monthlyCalificacion`/`monthlyCompliance` reusan el shape multi-año de `overview` para los lineChart de "Desempeño Individual - Año" y "Cumplimiento - Individual".
 
 ```json
 {
+  "kpisByYear": [
+    { "year": 2024, "calificacion": 4.36, "compliancePercent": 84, "completadas": 753, "caducadas": 148 }
+  ],
+  "kpis": { "calificacion": 4.74, "calificacionMax": 5.0, "calificacionMin": 2.8, "compliancePercent": 91, "completadas": 1019, "caducadas": 98 },
+  "avgByYate": [{ "yate": "Tip Top V", "calificacion": 4.7 }],
+  "monthlyCalificacion": { "categories": [...], "series": [{ "name": "2026", "data": [...] }] },
+  "monthlyCompliance": { "categories": [...], "series": [{ "name": "2026", "data": [...] }] },
+  "monthlyCalificacionByYate": [
+    { "yate": "Koln", "categories": [...], "series": [{ "name": "2026", "data": [...] }] }
+  ],
   "months": [{ "month": "enero", "monthIndex": 1 }],
   "porEvaluado": [
     { "evaluado": "Fabian Narvaez Benavidez", "porMes": [{ "month": "enero", "monthIndex": 1, "valor": 4.89 }], "total": 4.77 }
@@ -102,16 +133,26 @@ Query: `yate?`, `evaluado?`, `funcion?`, `anio?`.
   ]
 }
 ```
-`porEvaluadorMensual.valor` y `.total` son compliance % (0-100), no calificación.
+`porEvaluadorMensual.valor` y `.total` son compliance % (0-100), no calificación. `porEvaluado`, `porEvaluadorMensual` y `porEvaluadorTrimestre` no cambian respecto a la versión anterior de este contrato — ya cubrían, respectivamente, los pivots por Evaluado×Mes de "Desempeño individual 360", por Evaluador×Mes de "Cumplimiento - Individual" y por Evaluador×Trimestre de "Desempeño individual 360".
 
 ### 3.4 `GET /reports/desempeno/preguntas`
 Query: `evaluado?`, `funcion?`, `anio?`.
+
+Cubre la página "Liderazgo - Capitanes Ítems" del pbix, que tiene dos pivots: uno por Evaluador (ya cubierto por `porEvaluador`, sin cambios) y uno por Función×Mes (`porFuncionMes`, nuevo — antes no estaba en el contrato). El pivot original agrupa filas por Año+Mes, no solo por Mes; para no mezclar años distintos bajo el mismo mes cuando `anio` no se filtra, `porMes` y `porFuncionMes.porMes` ahora incluyen `year` explícito en cada fila (antes `porMes` no lo tenía — era ambiguo con más de un año de data).
 
 ```json
 {
   "competencias": ["Supervisión Cubierta", "Comunicación Clara"],
   "porMes": [
-    { "month": "enero", "monthIndex": 1, "valores": [{ "etiqueta": "Supervisión Cubierta", "valor": 4.70 }] }
+    { "year": 2026, "month": "enero", "monthIndex": 1, "valores": [{ "etiqueta": "Supervisión Cubierta", "valor": 4.70 }] }
+  ],
+  "porFuncionMes": [
+    {
+      "funcion": "Capitán",
+      "porMes": [
+        { "year": 2026, "month": "enero", "monthIndex": 1, "valores": [{ "etiqueta": "Supervisión Cubierta", "valor": 4.70 }] }
+      ]
+    }
   ],
   "porEvaluador": [
     { "evaluador": "Richard Alexander Mejia Chele", "valores": [{ "etiqueta": "Supervisión Cubierta", "valor": 3.44 }], "calificacion": 3.53 }
@@ -132,7 +173,9 @@ Sin tabla ni endpoint nuevo en base de datos — todo se calcula al vuelo sobre 
 ## 5. Diseño de frontend (contrato para implementación futura en `interno-react`)
 
 - 4 páginas bajo `src/containers/operations/surveys/reporting/desempeno/`: `OverviewPage.jsx`, `YatesPage.jsx`, `PersonasPage.jsx`, `PreguntasPage.jsx`, reemplazando la entrada de menú que hoy apunta a `EvaluationReportPowerBI.jsx`.
-- Cada página trae su(s) `ChartX.jsx` con `react-apexcharts`, siguiendo la convención de `ChartOne.jsx`: `type: 'line'` para tendencias mensuales (una serie por año o por yate), `type: 'bar'` para el promedio por yate, tablas HTML con Tailwind para las vistas de Personas y Preguntas (no hay chart nativo natural para esas).
+- Cada página trae su(s) `ChartX.jsx` con `react-apexcharts`, siguiendo la convención de `ChartOne.jsx`: `type: 'line'` para tendencias mensuales (una serie por año o por yate), `type: 'bar'` para el promedio por yate, tablas HTML con Tailwind para los pivots (Personas y Preguntas).
+- **Corrección sobre la versión anterior de este spec**: `PersonasPage.jsx` no es solo tablas — el pbix ("Barco - Capitán", "Desempeño Individual - Año", "Cumplimiento - Individual") sí tiene KPI cards y los mismos `YateBarChart`/`MonthlyLineChart` que ya existen para `YatesPage.jsx`; se reutilizan ahí en vez de crear componentes nuevos. `PreguntasPage.jsx` sí se queda solo con tablas (`DynamicValueTable`), incluyendo una nueva para `porFuncionMes` — el pbix la muestra como pivot, no como chart.
+- `DesempenoFilterBar.jsx` necesita un filtro `area` nuevo (slicer "Área" del pbix, presente en "Desempeño Individual - Año" y ausente hoy del componente).
 - Mismos roles de acceso que tenía el menú de Power BI: `admin`, `psicologos`, `gerencia_gps`, `gerencia_uio`.
 - Estado/fetch: un slice de Redux por vista (o un solo `desempenoDashboard.slice.js` con 4 thunks), reemplazando `powerbi.slice.js`.
 
@@ -165,3 +208,6 @@ Domain tests (Jest + Supertest, DB real vía `tests/helpers/testApp.js`), un arc
 
 - **Filtro `funcion`** en `/personas` y `/preguntas`: se asume que filtra por `Positions.name` (cargo) del evaluado, igual que la columna "Función" del Excel. Si en implementación se descubre que el Excel usa un concepto distinto de "función" al de `Positions`, se ajusta sin cambiar el contrato de query params.
 - **Formularios sin 9 preguntas numéricas**: si un formulario tiene menos o más de 9 preguntas de escala, `preguntas.competencias` refleja las que existan realmente (no se asume un número fijo de 9).
+- **Filtro `area`** (nuevo en `/personas`): se asume la misma convención que `funcion` — filtra por la columna `Área` de `Report_General_Final`. Si esa columna no tiene un origen claro en el modelo actual (`FormRespond`/`FormAnswers`/`Positions`/`Staff`), se ajusta el cálculo en implementación sin cambiar el contrato del query param.
+- **`kpis.calificacionMax`/`calificacionMin`**: se asume que es el máximo/mínimo de `calificacion` entre las evaluaciones que matchean el filtro actual (no un máximo/mínimo histórico sin filtrar).
+- Esta revisión (2026-08-31, segunda pasada) ajusta el contrato para reflejar el diseño real de `Reporte Desempeño.pbix` — la primera versión de este spec asumía visualmente el patrón de `ChartOne.jsx` en vez de partir del pbix, lo que dejó fuera `porFuncionMes`, `area`, `calificacionMax/Min` y los charts de `personas`. El backend ya implementado (PR #17) sigue el contrato viejo; falta un incremento para estos campos nuevos.

--- a/src/controllers/reports/desempenoDashboard.controller.js
+++ b/src/controllers/reports/desempenoDashboard.controller.js
@@ -28,11 +28,12 @@ const getDesempenoYates = async (req, res, next) => {
 
 const getDesempenoPersonas = async (req, res, next) => {
     try {
-        const { yate, evaluado, funcion, anio } = req.query;
+        const { yate, evaluado, funcion, area, anio } = req.query;
         const personas = await getPersonas({
             yate: asString(yate),
             evaluado: asString(evaluado),
             funcion: asString(funcion),
+            area: asString(area),
             anio: asString(anio),
         });
         res.status(200).json(personas);

--- a/src/routes/reports/reports.routes.js
+++ b/src/routes/reports/reports.routes.js
@@ -252,7 +252,7 @@ router.get('/desempeno/yates', authJwt.verifyToken, authJwt.hasAnyRole(DESEMPENO
  * @openapi
  * /reports/desempeno/personas:
  *   get:
- *     summary: Calificación por evaluado y compliance por evaluador, con comentarios de texto libre
+ *     summary: KPIs, series mensuales y promedios por yate, calificación por evaluado y compliance por evaluador, con comentarios de texto libre
  *     tags: [Reports]
  *     security:
  *       - bearerAuth: []
@@ -280,7 +280,7 @@ router.get('/desempeno/yates', authJwt.verifyToken, authJwt.hasAnyRole(DESEMPENO
  *         description: Año para filtrar (opcional). Si se omite, los datos de distintos años se combinan en el mismo mes — se recomienda siempre pasar este filtro en producción.
  *     responses:
  *       200:
- *         description: Tablas por evaluado/evaluador + comentarios
+ *         description: KPIs (kpisByYear, kpis con calificacionMax/calificacionMin), promedios y series mensuales (avgByYate, monthlyCalificacion, monthlyCompliance, monthlyCalificacionByYate), tablas por evaluado/evaluador y comentarios de texto libre. A diferencia de /yates, aquí avgByYate y monthlyCalificacionByYate respetan el filtro yate actual (no siempre muestran las 4 embarcaciones).
  *       403:
  *         description: Token no proporcionado o rol no autorizado
  */
@@ -290,7 +290,7 @@ router.get('/desempeno/personas', authJwt.verifyToken, authJwt.hasAnyRole(DESEMP
  * @openapi
  * /reports/desempeno/preguntas:
  *   get:
- *     summary: Desglose de calificación por pregunta/competencia
+ *     summary: Desglose de calificación por pregunta/competencia, con series mensuales generales y por función
  *     tags: [Reports]
  *     security:
  *       - bearerAuth: []
@@ -307,10 +307,10 @@ router.get('/desempeno/personas', authJwt.verifyToken, authJwt.hasAnyRole(DESEMP
  *         name: anio
  *         schema:
  *           type: integer
- *         description: Año para filtrar (opcional). Si se omite, los datos de distintos años se combinan en el mismo mes/trimestre — se recomienda siempre pasar este filtro en producción.
+ *         description: Año para filtrar (opcional). porMes y porFuncionMes ya separan cada año en su propia fila, así que omitirlo no mezcla años.
  *     responses:
  *       200:
- *         description: Competencias + desglose mensual y por evaluador
+ *         description: Competencias + desglose mensual (porMes), desglose mensual por función (porFuncionMes) y por evaluador (porEvaluador)
  *       403:
  *         description: Token no proporcionado o rol no autorizado
  */

--- a/src/routes/reports/reports.routes.js
+++ b/src/routes/reports/reports.routes.js
@@ -270,6 +270,10 @@ router.get('/desempeno/yates', authJwt.verifyToken, authJwt.hasAnyRole(DESEMPENO
  *         schema:
  *           type: string
  *       - in: query
+ *         name: area
+ *         schema:
+ *           type: string
+ *       - in: query
  *         name: anio
  *         schema:
  *           type: integer

--- a/src/services/catalogs/staff.services.js
+++ b/src/services/catalogs/staff.services.js
@@ -89,6 +89,31 @@ class Staffervice {
         }
     }
 
+    static async getDepartmentsByFullNames(namePairs) {
+        try {
+            if (!namePairs || namePairs.length === 0) return new Map();
+
+            const staff = await Staff.findAll({
+                where: {
+                    active: true,
+                    [Op.or]: namePairs.map(({ firstName, lastName }) => ({ firstName, lastName })),
+                },
+                attributes: ['id', 'firstName', 'lastName'],
+                include: [{
+                    model: Departaments,
+                    as: 'staff_departament',
+                    attributes: ['id', 'name'],
+                }],
+            });
+
+            return new Map(
+                staff.map(s => [`${s.firstName} ${s.lastName}`, s.staff_departament?.name || null])
+            );
+        } catch (error) {
+            throw error;
+        }
+    }
+
     static async getStaffCompanies(staffId) {
         try {
             const result = await StaffCompany.findAll({

--- a/src/services/reports/desempenoDashboard.services.js
+++ b/src/services/reports/desempenoDashboard.services.js
@@ -326,9 +326,37 @@ function scoreForCompetencia(rows, competencia) {
     return round2(average(numeric));
 }
 
+function porMesFor(rows, competencias) {
+    const yearMonthKeys = [...new Set(rows.map((row) => {
+        const date = evaluationDate(row);
+        return `${date.getFullYear()}-${date.getMonth()}`;
+    }))]
+        .map((key) => {
+            const [year, monthIndex] = key.split('-').map(Number);
+            return { year, monthIndex };
+        })
+        .sort((a, b) => (a.year - b.year) || (a.monthIndex - b.monthIndex));
+
+    return yearMonthKeys.map(({ year, monthIndex }) => {
+        const monthRows = rows.filter((row) => {
+            const date = evaluationDate(row);
+            return date.getFullYear() === year && date.getMonth() === monthIndex;
+        });
+        return {
+            year,
+            month: MESES[monthIndex],
+            monthIndex: monthIndex + 1,
+            valores: competencias.map((competencia) => ({
+                etiqueta: competencia,
+                valor: scoreForCompetencia(monthRows, competencia),
+            })),
+        };
+    });
+}
+
 async function getPreguntas({ evaluado, funcion, anio } = {}) {
     const allRows = await loadEvaluations();
-    const cargoMap = funcion ? await buildCargoMap(allRows) : new Map();
+    const cargoMap = await buildCargoMap(allRows);
 
     const rows = allRows.filter((row) => {
         if (evaluado && row.evaluated?.trim().toLowerCase() !== evaluado.trim().toLowerCase()) return false;
@@ -350,18 +378,14 @@ async function getPreguntas({ evaluado, funcion, anio } = {}) {
         });
     });
 
-    const monthIndexesPresent = [...new Set(rows.map((row) => evaluationDate(row).getMonth()))].sort((a, b) => a - b);
-    const porMes = monthIndexesPresent.map((monthIndex) => {
-        const monthRows = rows.filter((row) => evaluationDate(row).getMonth() === monthIndex);
-        return {
-            month: MESES[monthIndex],
-            monthIndex: monthIndex + 1,
-            valores: competencias.map((competencia) => ({
-                etiqueta: competencia,
-                valor: scoreForCompetencia(monthRows, competencia),
-            })),
-        };
-    });
+    const porMes = porMesFor(rows, competencias);
+
+    const porFuncionMes = [...groupRowsBy(rows, (row) => cargoMap.get(row.evaluated) || null).entries()]
+        .map(([funcionName, funcionRows]) => ({
+            funcion: funcionName,
+            porMes: porMesFor(funcionRows, competencias),
+        }))
+        .sort((a, b) => a.funcion.localeCompare(b.funcion));
 
     const porEvaluador = [...groupRowsBy(rows, (row) => row.evaluator).entries()]
         .map(([evaluador, evaluatorRows]) => ({
@@ -374,7 +398,7 @@ async function getPreguntas({ evaluado, funcion, anio } = {}) {
         }))
         .sort((a, b) => a.evaluador.localeCompare(b.evaluador));
 
-    return { competencias, porMes, porEvaluador };
+    return { competencias, porMes, porFuncionMes, porEvaluador };
 }
 
 module.exports = {

--- a/src/services/reports/desempenoDashboard.services.js
+++ b/src/services/reports/desempenoDashboard.services.js
@@ -100,6 +100,28 @@ async function buildCargoMap(rows) {
     );
 }
 
+async function buildAreaMap(rows) {
+    const uniqueEvaluados = [...new Set(rows.map((r) => r.evaluated).filter(Boolean))];
+    const namePairs = uniqueEvaluados
+        .map((evaluado) => ({
+            fullName: evaluado,
+            firstName: extractNombres(evaluado),
+            lastName: extractApellido(evaluado),
+        }))
+        .filter(({ firstName, lastName }) => firstName && lastName);
+
+    const areaByFullName = await Staffervice.getDepartmentsByFullNames(
+        namePairs.map(({ firstName, lastName }) => ({ firstName, lastName }))
+    );
+
+    return new Map(
+        namePairs.map(({ fullName, firstName, lastName }) => [
+            fullName,
+            areaByFullName.get(`${firstName} ${lastName}`) || null,
+        ])
+    );
+}
+
 async function getOverview(yateFilter) {
     const rows = (await loadEvaluations()).filter((row) => matchesYate(row, yateFilter));
     const years = [...new Set(rows.map((row) => evaluationDate(row).getFullYear()))].sort((a, b) => a - b);

--- a/src/services/reports/desempenoDashboard.services.js
+++ b/src/services/reports/desempenoDashboard.services.js
@@ -198,17 +198,54 @@ function groupRowsBy(rows, keyFn) {
     return groups;
 }
 
-async function getPersonas({ yate, evaluado, funcion, anio } = {}) {
+async function getPersonas({ yate, evaluado, funcion, area, anio } = {}) {
     const allRows = await loadEvaluations();
     const cargoMap = funcion ? await buildCargoMap(allRows) : new Map();
+    const areaMap = area ? await buildAreaMap(allRows) : new Map();
 
     const rows = allRows.filter((row) => {
         if (!matchesYate(row, yate)) return false;
         if (evaluado && row.evaluated?.trim().toLowerCase() !== evaluado.trim().toLowerCase()) return false;
         if (funcion && (cargoMap.get(row.evaluated) || '').toLowerCase() !== funcion.trim().toLowerCase()) return false;
+        if (area && (areaMap.get(row.evaluated) || '').toLowerCase() !== area.trim().toLowerCase()) return false;
         if (anio && evaluationDate(row).getFullYear() !== Number(anio)) return false;
         return true;
     });
+
+    const years = [...new Set(rows.map((row) => evaluationDate(row).getFullYear()))].sort((a, b) => a - b);
+    const kpisByYear = years.map((year) => {
+        const yearRows = rows.filter((row) => evaluationDate(row).getFullYear() === year);
+        const completadas = yearRows.filter((row) => row.state === 'Completada').length;
+        const caducadas = yearRows.filter((row) => row.state === 'Caducada').length;
+        return {
+            year,
+            calificacion: scoreValue(yearRows),
+            compliancePercent: compliancePercent(completadas, caducadas),
+            completadas,
+            caducadas,
+        };
+    });
+
+    const completadas = rows.filter((row) => row.state === 'Completada').length;
+    const caducadas = rows.filter((row) => row.state === 'Caducada').length;
+    const scoresPerRow = rows.map(evaluationScore).filter((s) => s !== null);
+
+    const yateGroups = new Map();
+    rows.forEach((row) => {
+        const rowYate = yateName(row);
+        if (!rowYate) return;
+        if (!yateGroups.has(rowYate)) yateGroups.set(rowYate, []);
+        yateGroups.get(rowYate).push(row);
+    });
+    const avgByYate = [...yateGroups.entries()]
+        .map(([rowYate, yateRows]) => ({ yate: rowYate, calificacion: scoreValue(yateRows) }))
+        .sort((a, b) => a.yate.localeCompare(b.yate));
+    const monthlyCalificacionByYate = [...yateGroups.entries()]
+        .map(([rowYate, yateRows]) => ({
+            yate: rowYate,
+            ...monthlySeriesByYear(yateRows, scoreValue),
+        }))
+        .sort((a, b) => a.yate.localeCompare(b.yate));
 
     const monthIndexesPresent = [...new Set(rows.map((row) => evaluationDate(row).getMonth()))].sort((a, b) => a - b);
     const months = monthIndexesPresent.map((monthIndex) => ({ month: MESES[monthIndex], monthIndex: monthIndex + 1 }));
@@ -257,7 +294,26 @@ async function getPersonas({ yate, evaluado, funcion, anio } = {}) {
             .map((r) => ({ evaluado: row.evaluated, evaluador: row.evaluator, texto: r.answer }))
     );
 
-    return { months, porEvaluado, porEvaluadorMensual, porEvaluadorTrimestre, comentarios };
+    return {
+        kpisByYear,
+        kpis: {
+            calificacion: scoreValue(rows),
+            calificacionMax: scoresPerRow.length ? round2(Math.max(...scoresPerRow)) : null,
+            calificacionMin: scoresPerRow.length ? round2(Math.min(...scoresPerRow)) : null,
+            compliancePercent: compliancePercent(completadas, caducadas),
+            completadas,
+            caducadas,
+        },
+        avgByYate,
+        monthlyCalificacion: monthlySeriesByYear(rows, scoreValue),
+        monthlyCompliance: monthlySeriesByYear(rows, complianceValue),
+        monthlyCalificacionByYate,
+        months,
+        porEvaluado,
+        porEvaluadorMensual,
+        porEvaluadorTrimestre,
+        comentarios,
+    };
 }
 
 function scoreForCompetencia(rows, competencia) {

--- a/tests/domain/reports/desempeno/desempenoDashboard.personas.test.js
+++ b/tests/domain/reports/desempeno/desempenoDashboard.personas.test.js
@@ -1,10 +1,11 @@
 const { bootTestApp, shutdownTestApp } = require('../../../helpers/testApp');
-const { createCompanyWithYacht } = require('../../../helpers/staffFixtures');
+const { createCompanyWithYacht, createDepartment, createPosition } = require('../../../helpers/staffFixtures');
 const { setUpdatedAt } = require('../../../helpers/dateFixtures');
 const Form = require('../../../../src/models/operations/surveys/form.models');
 const FormQuestion = require('../../../../src/models/operations/surveys/formQuestion.models');
 const FormRespond = require('../../../../src/models/operations/surveys/formRespond.models');
 const FormAnswers = require('../../../../src/models/operations/surveys/formAnswers.models');
+const Staff = require('../../../../src/models/catalogs/staff.models');
 const { getPersonas } = require('../../../../src/services/reports/desempenoDashboard.services');
 
 beforeAll(async () => {
@@ -57,5 +58,75 @@ describe('desempenoDashboard.services getPersonas', () => {
             evaluador: `Evaluador Personas ${caseSuffix}`,
             texto: 'Buen desempeño este mes.',
         });
+    });
+
+    it('returns kpisByYear, kpis with max/min, and per-yate breakdowns scoped to the current filter', async () => {
+        const caseSuffix = `${Date.now()}`;
+        const yachtName = `Personas Kpi Yacht ${caseSuffix}`;
+        const { company } = await createCompanyWithYacht(`Personas Kpi Co ${caseSuffix}`, yachtName);
+        const form = await Form.create({ name: `Form Personas Kpi ${caseSuffix}`, positions: [] });
+        const question = await FormQuestion.create({ formId: form.id, title: 'Pregunta 1', type: 'scale' });
+
+        const high = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador Kpi ${caseSuffix}`, evaluated: `Evaluado Kpi Alto ${caseSuffix}`,
+            expirationDate: new Date('2025-08-01'),
+        });
+        await setUpdatedAt('form_responds', high.id, '2025-08-05T12:00:00');
+        await FormAnswers.create({ respuestaId: high.id, questionId: question.id, answer: '5' });
+
+        const low = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador Kpi ${caseSuffix}`, evaluated: `Evaluado Kpi Bajo ${caseSuffix}`,
+            expirationDate: new Date('2025-08-01'),
+        });
+        await setUpdatedAt('form_responds', low.id, '2025-08-10T12:00:00');
+        await FormAnswers.create({ respuestaId: low.id, questionId: question.id, answer: '2' });
+
+        const result = await getPersonas({ yate: yachtName, anio: 2025 });
+        const year2025 = result.kpisByYear.find((k) => k.year === 2025);
+
+        expect(year2025.calificacion).toBe(3.5);
+        expect(result.kpis.calificacionMax).toBe(5);
+        expect(result.kpis.calificacionMin).toBe(2);
+        expect(result.avgByYate.find((y) => y.yate === yachtName).calificacion).toBe(3.5);
+        expect(result.monthlyCalificacionByYate.find((y) => y.yate === yachtName)).toBeDefined();
+    });
+
+    it('filters by area (departamento) resolved from the evaluado staff record', async () => {
+        const caseSuffix = `${Date.now()}`;
+        const { company } = await createCompanyWithYacht(`Personas Area Co ${caseSuffix}`);
+        const department = await createDepartment(`Cubierta ${caseSuffix}`);
+        const position = await createPosition(`Marinero ${caseSuffix}`);
+        const firstName = `AreaFN${caseSuffix}`;
+        const lastName = 'Perez Lopez';
+        await Staff.create({
+            firstName,
+            lastName,
+            email: `area-test-${caseSuffix}@example.com`,
+            cellPhone: '0966666666',
+            password: 'Sup3rSecret!',
+            departamentId: department.id,
+            positionId: position.id,
+            contractType: 'Fijo',
+            active: true,
+        });
+        const evaluatedFullName = `${firstName} ${lastName}`;
+
+        const form = await Form.create({ name: `Form Personas Area ${caseSuffix}`, positions: [] });
+        const question = await FormQuestion.create({ formId: form.id, title: 'Pregunta 1', type: 'scale' });
+        const respond = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador Area ${caseSuffix}`, evaluated: evaluatedFullName,
+            expirationDate: new Date('2025-07-01'),
+        });
+        await setUpdatedAt('form_responds', respond.id, '2025-07-05T12:00:00');
+        await FormAnswers.create({ respuestaId: respond.id, questionId: question.id, answer: '5' });
+
+        const matched = await getPersonas({ area: department.name, anio: 2025 });
+        const unmatched = await getPersonas({ area: 'Area Que No Existe', anio: 2025 });
+
+        expect(matched.porEvaluado.some((p) => p.evaluado === evaluatedFullName)).toBe(true);
+        expect(unmatched.porEvaluado.some((p) => p.evaluado === evaluatedFullName)).toBe(false);
     });
 });

--- a/tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js
+++ b/tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js
@@ -52,7 +52,7 @@ describe('desempenoDashboard.services getPreguntas', () => {
         const { company } = await createCompanyWithYacht(`Preguntas FuncionMes Co ${caseSuffix}`);
         const department = await createDepartment(`Cubierta ${caseSuffix}`);
         const position = await createPosition(`Capitan ${caseSuffix}`);
-        const firstName = `PFM${caseSuffix}`;
+        const firstName = `Pfm${caseSuffix}`;
         const lastName = 'Rios Vera';
         await Staff.create({
             firstName,

--- a/tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js
+++ b/tests/domain/reports/desempeno/desempenoDashboard.preguntas.test.js
@@ -1,10 +1,11 @@
 const { bootTestApp, shutdownTestApp } = require('../../../helpers/testApp');
-const { createCompanyWithYacht } = require('../../../helpers/staffFixtures');
+const { createCompanyWithYacht, createDepartment, createPosition } = require('../../../helpers/staffFixtures');
 const { setUpdatedAt } = require('../../../helpers/dateFixtures');
 const Form = require('../../../../src/models/operations/surveys/form.models');
 const FormQuestion = require('../../../../src/models/operations/surveys/formQuestion.models');
 const FormRespond = require('../../../../src/models/operations/surveys/formRespond.models');
 const FormAnswers = require('../../../../src/models/operations/surveys/formAnswers.models');
+const Staff = require('../../../../src/models/catalogs/staff.models');
 const { getPreguntas } = require('../../../../src/services/reports/desempenoDashboard.services');
 
 beforeAll(async () => {
@@ -44,5 +45,46 @@ describe('desempenoDashboard.services getPreguntas', () => {
         const evaluadorRow = result.porEvaluador.find((r) => r.evaluador === `Evaluador Preguntas ${caseSuffix}`);
         expect(evaluadorRow.calificacion).toBe(4);
         expect(evaluadorRow.valores.find((v) => v.etiqueta === 'Comunicación Clara').valor).toBe(4);
+    });
+
+    it('includes year on porMes rows and breaks calificación down by función×mes via porFuncionMes', async () => {
+        const caseSuffix = `${Date.now()}`;
+        const { company } = await createCompanyWithYacht(`Preguntas FuncionMes Co ${caseSuffix}`);
+        const department = await createDepartment(`Cubierta ${caseSuffix}`);
+        const position = await createPosition(`Capitan ${caseSuffix}`);
+        const firstName = `PFM${caseSuffix}`;
+        const lastName = 'Rios Vera';
+        await Staff.create({
+            firstName,
+            lastName,
+            email: `pfm-test-${caseSuffix}@example.com`,
+            cellPhone: '0966666666',
+            password: 'Sup3rSecret!',
+            departamentId: department.id,
+            positionId: position.id,
+            contractType: 'Fijo',
+            active: true,
+        });
+        const evaluatedFullName = `${firstName} ${lastName}`;
+
+        const form = await Form.create({ name: `Form Preguntas FuncionMes ${caseSuffix}`, positions: [] });
+        const question = await FormQuestion.create({ formId: form.id, title: 'Liderazgo', type: 'scale' });
+        const respond = await FormRespond.create({
+            companyId: company.id, formId: form.id, state: 'Completada',
+            evaluator: `Evaluador FuncionMes ${caseSuffix}`, evaluated: evaluatedFullName,
+            expirationDate: new Date('2025-09-01'),
+        });
+        await setUpdatedAt('form_responds', respond.id, '2025-09-10T12:00:00');
+        await FormAnswers.create({ respuestaId: respond.id, questionId: question.id, answer: '4' });
+
+        const result = await getPreguntas({ anio: 2025 });
+
+        const septiembreRow = result.porMes.find((m) => m.year === 2025 && m.monthIndex === 9);
+        expect(septiembreRow).toBeDefined();
+
+        const funcionRow = result.porFuncionMes.find((f) => f.funcion === position.name);
+        expect(funcionRow).toBeDefined();
+        const funcionSeptiembre = funcionRow.porMes.find((m) => m.year === 2025 && m.monthIndex === 9);
+        expect(funcionSeptiembre.valores.find((v) => v.etiqueta === 'Liderazgo').valor).toBe(4);
     });
 });

--- a/tests/domain/reports/desempeno/desempenoDashboard.routes.test.js
+++ b/tests/domain/reports/desempeno/desempenoDashboard.routes.test.js
@@ -36,20 +36,25 @@ describe('GET /api/reports/desempeno/*', () => {
         expect(response.body).toHaveProperty('kpis');
     });
 
-    it('returns the personas shape', async () => {
+    it('returns the personas shape, including the new yearly/per-yate breakdowns', async () => {
         const response = await withAuth(request(app).get('/api/reports/desempeno/personas'), adminToken);
 
         expect(response.status).toBe(200);
         expect(response.body).toHaveProperty('porEvaluado');
         expect(response.body).toHaveProperty('comentarios');
+        expect(response.body).toHaveProperty('kpisByYear');
+        expect(response.body).toHaveProperty('kpis');
+        expect(response.body).toHaveProperty('avgByYate');
+        expect(response.body).toHaveProperty('monthlyCalificacionByYate');
     });
 
-    it('returns the preguntas shape', async () => {
+    it('returns the preguntas shape, including porFuncionMes', async () => {
         const response = await withAuth(request(app).get('/api/reports/desempeno/preguntas'), adminToken);
 
         expect(response.status).toBe(200);
         expect(response.body).toHaveProperty('competencias');
         expect(response.body).toHaveProperty('porMes');
+        expect(response.body).toHaveProperty('porFuncionMes');
     });
 
     it('returns 403 without a token', async () => {


### PR DESCRIPTION
## Summary
- Adds `area` (departamento) filter to `GET /reports/desempeno/personas`, plus `kpisByYear`, `kpis` (with `calificacionMax`/`calificacionMin`), `avgByYate`, `monthlyCalificacion`, `monthlyCompliance`, `monthlyCalificacionByYate` — closing the gap between the pbix-grounded spec and PR #17's original contract.
- Adds `year` to `porMes` rows and a new `porFuncionMes` (función×mes) breakdown to `GET /reports/desempeno/preguntas`.
- Updates `@openapi` docs on both routes to match the new response shape and query params.
- Second-pass spec revision (`docs/superpowers/specs/2026-08-31-surveys-desempeno-dashboard-design.md`) grounding the contract directly against `Reporte Desempeño.pbix`'s 10 pages instead of the generic `ChartOne.jsx` pattern assumed in the first pass.

Built with superpowers:subagent-driven-development — 4 tasks, each with an independent implementer + task review; one fix round in Task 3 (test fixture naming); final whole-branch review (opus) found no bugs, only 2 doc-drift issues in `@openapi` blocks, fixed and re-reviewed clean.

## Test plan
- [x] `tests/domain/reports/desempeno/*` — 14/14 passing (`--runInBand`)
- [x] Full project suite — 415/417 passing; the 2 failures are in `tests/domain/operations-shippingGuide/shippingGuide.test.js` (missing `uploads/pdfs/guides/` directory in this environment), pre-existing and unrelated to this branch — confirmed zero shippingGuide files touched by this diff
- [x] `swagger-jsdoc` validated the updated `@openapi` blocks parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RvzzQP8LRdn5Qi19phvCD